### PR TITLE
Add missing <stdexcept>

### DIFF
--- a/lib/src/value.cpp
+++ b/lib/src/value.cpp
@@ -1,3 +1,4 @@
+#include <stdexcept>
 #include "value.hpp"
 #include "container.hpp"
 


### PR DESCRIPTION
An error is thrown in `std::invalid_argument` under Mingw-w64 during build of QSchematic