### PR TITLE
Add YAML support for GPDS

### DIFF
--- a/examples/basic/main.cpp
+++ b/examples/basic/main.cpp
@@ -53,7 +53,7 @@ int main()
         catalog.cars.push_front(car);
     }
 
-    // To/from file
+    // To/from file XML
     {
         const std::filesystem::path filepath = "catalog.xml";
 
@@ -72,6 +72,34 @@ int main()
         {
             car_catalog catalog1;
             const auto&[success, msg] = catalog1.from_file(filepath, "car-catalog");
+            if (!success) {
+                std::cerr << "could not load `catalog` from file: " << msg << std::endl;
+                return EXIT_FAILURE;
+            }
+
+            std::cout << "successfully deserialized 'catalog' from file: " << filepath << std::endl;
+        }
+    }
+
+    // To/from file YAML
+    {
+        const std::filesystem::path filepath = "catalog.yaml";
+
+        // Serialize to file
+        {
+            const auto&[success, msg] = catalog.to_file(filepath, "car-catalog", gpds::serialize::mode::YAML);
+            if (!success) {
+                std::cerr << "could not store 'catalog' in file: " << msg << std::endl;
+                return EXIT_FAILURE;
+            }
+
+            std::cout << "successfully serialized 'catalog' to file: " << filepath << std::endl;
+        }
+
+        // Deserialize from file
+        {
+            car_catalog catalog1;
+            const auto&[success, msg] = catalog1.from_file(filepath, "car-catalog", gpds::serialize::mode::YAML);
             if (!success) {
                 std::cerr << "could not load `catalog` from file: " << msg << std::endl;
                 return EXIT_FAILURE;

--- a/examples/basic/main.cpp
+++ b/examples/basic/main.cpp
@@ -1,4 +1,5 @@
 #include <gpds/archiver_xml.hpp>
+#include <gpds/archiver_yaml.hpp>
 
 #include "carcatalog.h"
 

--- a/examples/basic/main.cpp
+++ b/examples/basic/main.cpp
@@ -81,7 +81,7 @@ int main()
         }
     }
 
-    // To/from string
+    // To/from string XML
     {
         std::string str;
 
@@ -100,6 +100,34 @@ int main()
         {
             car_catalog catalog1;
             const auto&[success, msg] = catalog1.from_string(str, "car-catalog");
+            if (!success) {
+                std::cerr << "could not load `catalog` from string: " << msg << std::endl;
+                return EXIT_FAILURE;
+            }
+
+            std::cout << "successfully deserialized 'catalog' from string." << std::endl;
+        }
+    }
+
+    // To/from string YAML
+    {
+        std::string str;
+
+        // Serialize to string
+        {
+            const auto& [success, msg] = catalog.to_string(str, "car-catalog", gpds::serialize::mode::YAML);
+            if (!success) {
+                std::cerr << "could not store 'catalog' in string: " << msg << std::endl;
+                return EXIT_FAILURE;
+            }
+
+            std::cout << "successfully serialized 'catalog' to string:\n" << str << std::endl;
+        }
+
+        // Deserialize form string
+        {
+            car_catalog catalog1;
+            const auto&[success, msg] = catalog1.from_string(str, "car-catalog", gpds::serialize::mode::YAML);
             if (!success) {
                 std::cerr << "could not load `catalog` from string: " << msg << std::endl;
                 return EXIT_FAILURE;

--- a/lib/3rdparty/miniyaml/.gitignore
+++ b/lib/3rdparty/miniyaml/.gitignore
@@ -1,0 +1,64 @@
+# Directories #
+lib
+bin
+doc
+build
+enc_temp_folder
+
+# Temporary
+*~
+*.tlog
+Valgrind*
+CppCheckResults*
+
+# Build
+*.exp
+*.ncb
+*.suo
+*.user
+*.pdb
+*.sdf
+*.opensdf
+*.opendb
+*.layout
+*.cbTemp
+*.depend
+*.log
+*.ilk
+*.idb
+*.db
+.vs
+
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/lib/3rdparty/miniyaml/.gitmodules
+++ b/lib/3rdparty/miniyaml/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/googletest"]
+	path = test/googletest
+	url = https://github.com/google/googletest

--- a/lib/3rdparty/miniyaml/.travis.yml
+++ b/lib/3rdparty/miniyaml/.travis.yml
@@ -1,0 +1,24 @@
+language:
+  - cpp
+
+compiler:
+  - gcc
+  - clang
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - valgrind
+
+script:
+  - cd test/googletest/googletest/make/
+  - make
+  - cd ../../../
+  - make
+  - cd ../bin/
+  - valgrind --leak-check=full --track-origins=yes --error-exitcode=1 ./test
+
+notifications:
+  email: false

--- a/lib/3rdparty/miniyaml/LICENSE
+++ b/lib/3rdparty/miniyaml/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Jimmie Bergmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/3rdparty/miniyaml/README.md
+++ b/lib/3rdparty/miniyaml/README.md
@@ -1,0 +1,76 @@
+# mini-yaml
+[![Build Status](https://travis-ci.org/jimmiebergmann/mini-yaml.svg?branch=master)](https://github.com/jimmiebergmann/mini-yaml#build-status)  
+Single header YAML 1.0 C++11 serializer/deserializer.
+
+## Quickstart
+#### file.txt
+```
+key: foo bar
+list:
+  - hello world
+  - integer: 123
+    boolean: true
+```
+#### .cpp
+```cpp
+Yaml::Node root;
+Yaml::Parse(root, "file.txt");
+
+// Print all scalars.
+std::cout << root["key"].As<std::string>() << std::endl;
+std::cout << root["list"][0].As<std::string>() << std::endl;
+std::cout << root["list"][1]["integer"].As<int>() << std::endl;
+std::cout << root["list"][1]["boolean"].As<bool>() << std::endl;
+
+// Iterate second sequence item.
+Node & item = root[1];
+for(auto it = item.Begin(); it != item.End(); it++)
+{
+    std::cout << (*it).first << ": " << (*it).second.As<string>() << std::endl;
+}
+```
+#### Output
+```
+foo bar
+hello world
+123
+1
+integer: 123
+boolean: true
+```
+
+See  [Best practice](https://github.com/jimmiebergmann/mini-yaml#best-practice).
+
+## Usage
+Put [/yaml](https://github.com/jimmiebergmann/mini-yaml/blob/master/yaml) in your project directory and simply #include "[yaml/yaml.hpp](https://github.com/jimmiebergmann/mini-yaml/blob/master/yaml/yaml.hpp)".
+See [examples/FirstExample.cpp](https://github.com/jimmiebergmann/mini-yaml/blob/master/examples/FirstExample.cpp) for additional examples.
+
+## Best practice
+Always use references when accessing node content, if not intended to make a copy. Modifying copied node wont affect the original node content.  
+See example:
+```cpp
+Yaml::Node root;
+
+Yaml::Node & ref = root;  // The content of "root" is not being copied.
+ref["key"] = "value";     // Modifying "root" node content.
+
+Yaml::Node copy = root;   // The content of "root" is copied to "copy".
+                          // Slow operation if "root" contains a lot of content.
+copy["key"] = "value";    // Modifying "copy" node content. "root" is left untouched.
+```
+
+## Build status
+Builds are passed if all tests are good and no memory leaks were found.
+
+| Branch | Status |
+| ------ | ------ |
+| master | [![Build Status](https://travis-ci.org/jimmiebergmann/mini-yaml.svg?branch=master)](https://travis-ci.org/jimmiebergmann/mini-yaml) |
+| dev | [![Build Status](https://travis-ci.org/jimmiebergmann/mini-yaml.svg?branch=dev)](https://travis-ci.org/jimmiebergmann/mini-yaml)|
+
+## Todo
+- Parse/serialize tags(!!type).
+- Parse anchors.
+- Parse flow sequences/maps.
+- Parse complex keys.
+- Parse sets.
+

--- a/lib/3rdparty/miniyaml/codeblocks/FirstExample.cbp
+++ b/lib/3rdparty/miniyaml/codeblocks/FirstExample.cbp
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<CodeBlocks_project_file>
+	<FileVersion major="1" minor="6" />
+	<Project>
+		<Option title="FirstExample" />
+		<Option pch_mode="2" />
+		<Option compiler="gcc" />
+		<Build>
+			<Target title="Debug">
+				<Option output="../bin/FirstExample-d" prefix_auto="1" extension_auto="1" />
+				<Option working_dir="../bin" />
+				<Option object_output="../obj/Debug/" />
+				<Option type="1" />
+				<Option compiler="gcc" />
+				<Compiler>
+					<Add option="-g" />
+					<Add directory="../yaml" />
+				</Compiler>
+			</Target>
+			<Target title="Release">
+				<Option output="../bin/FirstExample" prefix_auto="1" extension_auto="1" />
+				<Option working_dir="../bin" />
+				<Option object_output="../obj/Release/" />
+				<Option type="1" />
+				<Option compiler="gcc" />
+				<Compiler>
+					<Add option="-O2" />
+					<Add directory="../yaml" />
+				</Compiler>
+				<Linker>
+					<Add option="-s" />
+				</Linker>
+			</Target>
+		</Build>
+		<Compiler>
+			<Add option="-Wall" />
+		</Compiler>
+		<Unit filename="../examples/FirstExample.cpp" />
+		<Unit filename="../yaml/yaml.cpp" />
+		<Unit filename="../yaml/yaml.hpp" />
+		<Extensions>
+			<code_completion />
+			<debugger>
+				<search_path add="../examples" />
+			</debugger>
+			<envvars />
+		</Extensions>
+	</Project>
+</CodeBlocks_project_file>

--- a/lib/3rdparty/miniyaml/codeblocks/Yaml.workspace
+++ b/lib/3rdparty/miniyaml/codeblocks/Yaml.workspace
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<CodeBlocks_workspace_file>
+	<Workspace title="Yaml">
+		<Project filename="FirstExample.cbp" />
+		<Project filename="test.cbp" />
+	</Workspace>
+</CodeBlocks_workspace_file>

--- a/lib/3rdparty/miniyaml/codeblocks/test.cbp
+++ b/lib/3rdparty/miniyaml/codeblocks/test.cbp
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<CodeBlocks_project_file>
+	<FileVersion major="1" minor="6" />
+	<Project>
+		<Option title="test" />
+		<Option pch_mode="2" />
+		<Option compiler="gcc" />
+		<Build>
+			<Target title="Release">
+				<Option output="../bin/test" prefix_auto="1" extension_auto="1" />
+				<Option working_dir="../bin" />
+				<Option object_output="../obj/test/release" />
+				<Option type="1" />
+				<Option compiler="gcc" />
+				<Compiler>
+					<Add option="-O2" />
+					<Add option="-std=c++11" />
+					<Add directory="../test/googletest/googletest/include" />
+					<Add directory="../yaml" />
+				</Compiler>
+				<Linker>
+					<Add option="-s" />
+					<Add library="../test/googletest/googletest/make/gtest_main.a" />
+					<Add library="pthread" />
+				</Linker>
+			</Target>
+			<Target title="Debug">
+				<Option output="../bin/test-d" prefix_auto="1" extension_auto="1" />
+				<Option working_dir="../bin" />
+				<Option object_output="../obj/test/debug" />
+				<Option type="1" />
+				<Option compiler="gcc" />
+				<Compiler>
+					<Add option="-std=c++11" />
+					<Add option="-g" />
+					<Add directory="../test/googletest/googletest/include" />
+					<Add directory="../yaml" />
+				</Compiler>
+				<Linker>
+					<Add library="../test/googletest/googletest/make/gtest_main.a" />
+					<Add library="pthread" />
+				</Linker>
+			</Target>
+		</Build>
+		<Compiler>
+			<Add option="-Wall" />
+		</Compiler>
+		<Unit filename="../test/test.cpp" />
+		<Unit filename="../yaml/yaml.cpp" />
+		<Unit filename="../yaml/yaml.hpp" />
+		<Extensions>
+			<envvars />
+			<code_completion />
+			<debugger />
+			<lib_finder disable_auto="1" />
+		</Extensions>
+	</Project>
+</CodeBlocks_project_file>

--- a/lib/3rdparty/miniyaml/examples/FirstExample.cpp
+++ b/lib/3rdparty/miniyaml/examples/FirstExample.cpp
@@ -1,0 +1,244 @@
+/*
+* MIT License
+*
+* Copyright(c) 2018 Jimmie Bergmann
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files(the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions :
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+*/
+
+#include <yaml.hpp>
+
+using namespace Yaml;
+
+static void Example1();
+static void Example2();
+static void Example3();
+static void Example4();
+
+int main()
+{
+    Example1();
+    Example2();
+    Example3();
+    Example4();
+
+	return 0;
+}
+
+void Example1()
+{
+    const std::string data =
+		"data1 : \t | \t \n"
+		"  Hello1\n"
+		"   world1.\n"
+		"data2 : \t > \t \n"
+		"  Hello2\n"
+		"   world2.\n"
+		"data3: \t |- \t \n"
+		"  Hello3\n"
+		"   world3.\n"
+		"data4 : \t >- \t \n"
+		"  Hello4\n"
+		"   world4.\n"
+		"data5: |\n"
+		"   hello: world5\n"
+		"    foo: bar5.\n"
+		"data6: 123\n"
+		"data7: 123.6\n";
+
+    Node root;
+    try
+    {
+        Parse(root, data);
+    }
+    catch (const Exception e)
+    {
+        std::cout << "Exception " << e.Type() << ": " << e.what() << std::endl;
+        return;
+    }
+
+    std::cout << root["data1"].As<std::string>() << std::endl;
+    std::cout << root["data2"].As<std::string>() << std::endl;
+    std::cout << root["data3"].As<std::string>() << std::endl;
+    std::cout << root["data4"].As<std::string>() << std::endl;
+    std::cout << root["data5"].As<std::string>() << std::endl;
+    std::cout << root["data6"].As<int>(0) << std::endl;
+    std::cout << root["data7"].As<float>(0.0f) << std::endl;
+}
+
+void Example2()
+{
+    const std::string data =
+		" - Hello world\n"
+		" - 123\n"
+		" - 123.4\n";
+
+    Node root;
+    try
+    {
+        Parse(root, data);
+        if(root.IsSequence() == false)
+        {
+            throw InternalException("Test: Root is not a sequence.");
+        }
+    }
+    catch (const Exception e)
+    {
+        std::cout << "Exception " << e.Type() << ": " << e.what() << std::endl;
+        return;
+    }
+
+    std::cout << root[0].As<std::string>() << std::endl;
+    std::cout << root[1].As<int>(0) << std::endl;
+    std::cout << root[2].As<float>(0.0f) << std::endl;
+}
+
+void Example3()
+{
+    const std::string data =
+        "data1: \n"
+        "  123\n"
+        "data2: Hello world\n"
+        "data3:\n"
+        "   - key1: 123\n"
+        "     key2: Test\n"
+		"   - Hello world\n"
+		"   - 123\n"
+		"   - 123.4\n";
+
+    Node root;
+    try
+    {
+        Parse(root, data);
+    }
+    catch (const Exception e)
+    {
+        std::cout << "Exception " << e.Type() << ": " << e.what() << std::endl;
+        return;
+    }
+
+    std::cout << root["data1"].As<int>(0) << std::endl;
+    std::cout << root["data2"].As<std::string>() << std::endl;
+    std::cout << root["data3"][0]["key1"].As<int>(0) << std::endl;
+    std::cout << root["data3"][0]["key2"].As<std::string>() << std::endl;
+    std::cout << root["data3"][1].As<std::string>() << std::endl;
+    std::cout << root["data3"][2].As<int>(0) << std::endl;
+    std::cout << root["data3"][3].As<float>(0.0f) << std::endl;
+}
+
+void Example4()
+{
+    Node root;
+    try
+    {
+        Parse(root, "../examples/data1.txt");
+    }
+    catch (const Exception e)
+    {
+        std::cout << "Exception " << e.Type() << ": " << e.what() << std::endl;
+        return;
+    }
+
+    try
+    {
+        Node & server = root["server"];
+        Node & services = root["services"];
+
+        if(server.IsMap() == false)
+        {
+            throw InternalException("Server is not of type Map.");
+        }
+        if(services.IsSequence() == false)
+        {
+            throw InternalException("Services is not of type sequence.");
+        }
+
+        std::cout << "Server:" << std::endl;
+        std::cout << "  max connections: " << server["max_connections"].As<int>(0) << std::endl;
+        std::cout << "  com port       : " << server["com_port"].As<unsigned short>(0) << std::endl;
+
+        std::cout << "Services:" << std::endl;
+        //for(size_t i = 0; i < services.Size(); i++)
+        size_t countS = 0;
+        for(auto itS = services.Begin(); itS != services.End(); itS++)
+        {
+            std::cout << " Service " << countS++ << std::endl;
+            Node & service = (*itS).second;
+
+           /* for(auto itSS = service.Begin(); itSS != service.End(); itSS++)
+            {
+                std::cout << "  " << (*itSS).first << ":  " << (*itSS).second.As<std::string>() << std::endl;
+            }*/
+
+            std::cout << "  enabled:         " << service["enabled"].As<bool>(false) << std::endl;
+            std::cout << "  name:            " << service["name"].As<std::string>() << std::endl;
+            std::cout << "  protocol:        " << service["protocol"].As<std::string>() << std::endl;
+            std::cout << "  host:            " << service["host"].As<std::string>() << std::endl;
+            std::cout << "  port:            " << service["port"].As<unsigned short>(0) << std::endl;
+            std::cout << "  balancing:       " << service["balancing"].As<std::string>("No balancing value.") << std::endl;
+            std::cout << "  max_connections: " << service["max_connections"].As<int>(99999) << std::endl;
+            std::cout << "  session:         " << service["session"].As<std::string>("No session value.") << std::endl;
+
+            Node & nodes = service["nodes"];
+            if(nodes.IsSequence() == false)
+            {
+                throw InternalException("Nodes is not of type sequence.");
+            }
+
+            std::cout << "  Nodes:" << std::endl;
+            //for(size_t i = 0; i < nodes.Size(); i++)
+            size_t countN = 0;
+            for(auto itN = nodes.Begin(); itN != nodes.End(); itN++)
+            {
+                std::cout << "   Node " << countN++ << std::endl;
+                Node & node = (*itN).second;//nodes[i];
+
+                std::cout << "    name:      " << node["name"].As<std::string>() << std::endl;
+                std::cout << "    protocol:  " << node["protocol"].As<std::string>() << std::endl;
+                std::cout << "    host:      " << node["host"].As<std::string>() << std::endl;
+                std::cout << "    port:      " << node["port"].As<unsigned short>(0) << std::endl;
+                std::cout << std::endl;
+            }
+
+            std::cout << std::endl;
+        }
+
+    }
+    catch (const Exception e)
+    {
+        std::cout << "Example exception " << e.Type() << ": " << e.what() << std::endl;
+        return;
+    }
+
+
+    try
+    {
+        Serialize(root, "../bin/out.txt");
+    }
+    catch (const Exception e)
+    {
+        std::cout << "Exception " << e.Type() << ": " << e.what() << std::endl;
+        std::cin.get();
+    }
+
+}
+
+
+

--- a/lib/3rdparty/miniyaml/examples/data1.txt
+++ b/lib/3rdparty/miniyaml/examples/data1.txt
@@ -1,0 +1,36 @@
+server:
+    max_connections:       512
+    com_port:              230
+services:
+    - enabled:             true
+      name:                service 1
+      protocol:            tcp
+      host:                127.0.0.1
+      port:                80
+      balancing:           round robin
+      max_connections:     5
+      session:             24s
+      buffer:
+            size:          8000
+            count:         128
+      nodes:
+          - name:          example.com
+            protocol:      tcp
+            host:          93.184.216.34
+            port:          80
+
+          - name:          example.org
+            protocol:      tcp
+            host:          93.184.216.34
+            port:          80
+    - name:                service 2
+      protocol:            tcp
+      host:                127.0.0.1
+      port:                8080
+      nodes:
+          - name:          example.com
+            protocol:      tcp
+            host:          93.184.216.34
+            port:          80
+
+            

--- a/lib/3rdparty/miniyaml/test/invalid.yaml
+++ b/lib/3rdparty/miniyaml/test/invalid.yaml
@@ -1,0 +1,29 @@
+#Scalar tests
+---
+|
+foo
+bar
+
+---
+key: "value
+
+---
+key: "val"ue"
+
+---
+key: val"ue"
+
+---
+key: value"
+
+---
+key: "value\"
+
+---
+"foo"
+"bar"
+
+---
+key:
+ "foo"
+ "bar"

--- a/lib/3rdparty/miniyaml/test/learnyaml.yaml
+++ b/lib/3rdparty/miniyaml/test/learnyaml.yaml
@@ -1,0 +1,162 @@
+# Slightly modified to fit our purpose.
+# Origin: https://learnxinyminutes.com/docs/yaml/
+
+# Comments in YAML look like this.
+
+################
+# SCALAR TYPES #
+################
+
+# Our root object (which continues for the entire document) will be a map,
+# which is equivalent to a dictionary, hash or object in other languages.
+key: value
+another_key: Another value goes here.
+a_number_value: 100
+scientific_notation: 1e+12
+# The number 1 will be interpreted as a number, not a boolean. if you want
+# it to be interpreted as a boolean, use true
+boolean: true
+null_value: null
+empty_value:
+key with spaces: value
+# Notice that strings don't need to be quoted. However, they can be.
+however: "A string, enclosed in quotes."
+"Keys: can be \"quoted\" too.": "Useful if you want to put a ':' in your key. Or use comment char(#)."
+
+# Multiple-line strings can be written either as a 'literal block' (using |),
+# or a 'folded block' (using '>').
+scalar_block:
+  block of text
+   will separate all lines
+ with spaces.
+
+literal_block: |
+    This entire block of text will be the value of the 'literal_block' key,      
+    with line breaks being preserved.
+
+    The literal continues until de-dented, and the leading indentation is
+    stripped.
+
+        Any lines that are 'more-indented' keep the rest of their indentation -
+        these lines will be indented by 4 spaces.
+folded_style: >
+    This entire block of text will be the value of 'folded_style', but this
+    time, all newlines will be replaced with a single space.
+
+    Blank lines, like above, are converted to a newline character.
+
+        'More-indented' lines keep their newlines, too -
+        this text will appear over two lines.
+
+####################
+# COLLECTION TYPES #
+####################
+
+# Nesting is achieved by indentation.
+a_nested_map:
+    key: value
+    another_key: Another Value
+    another_nested_map:
+        hello: hello
+
+# Maps don't have to have string keys.
+0.25: a float key
+
+# Keys can also be complex, like multi-line objects
+# We use ? followed by a space to indicate the start of a complex key.
+#? |
+#    This is a key
+#    that has multiple lines
+#: and this is its value
+
+# YAML also allows mapping between sequences with the complex key syntax
+# Some language parsers might complain
+# An example
+#? - Manchester United
+#  - Real Madrid
+#: [ 2001-01-01, 2002-02-02 ]
+
+# Sequences (equivalent to lists or arrays) look like this:
+a_sequence:
+
+    - Item 1
+    - Item 2
+    - 0.5 # sequences can contain disparate types.
+    - Item 4
+    - key: value
+      another_key: another_value
+    -
+
+        - This is a sequence
+        - 
+          inside another sequence
+
+# Since YAML is a superset of JSON, you can also write JSON-style maps and
+# sequences:
+#json_map: {"key": "value"}
+#json_seq: [3, 2, 1, "takeoff"]
+
+#######################
+# EXTRA YAML FEATURES #
+#######################
+
+# YAML also has a handy feature called 'anchors', which let you easily duplicate
+# content across your document. Both of these keys will have the same value:
+#anchored_content: &anchor_name This string will appear as the value of two keys.
+#other_anchor: *anchor_name
+#
+# Anchors can be used to duplicate/inherit properties
+#base: &base
+#    name: Everyone has same name
+#
+#foo: &foo
+#    <<: *base
+#    age: 10
+#
+#bar: &bar
+#    <<: *base
+#    age: 20
+#
+# foo and bar would also have name: Everyone has same name
+
+# YAML also has tags, which you can use to explicitly declare types.
+#explicit_string: !!str 0.5
+# Some parsers implement language specific tags, like this one for Python's
+# complex number type.
+#python_complex_number: !!python/complex 1+2j
+
+# We can also use yaml complex keys with language specific tags
+#? !!python/tuple [5, 7]
+#: Fifty Seven
+# Would be {(5, 7): 'Fifty Seven'} in Python
+
+####################
+# EXTRA YAML TYPES #
+####################
+
+# Strings and numbers aren't the only scalars that YAML can understand.
+# ISO-formatted date and datetime literals are also parsed.
+datetime: 2001-12-15T02:59:43.1Z
+datetime_with_spaces: 2001-12-14 21:59:43.10 -5
+date: 2002-12-14
+
+# The !!binary tag indicates that a string is actually a base64-encoded
+# representation of a binary blob.
+#gif_file: !!binary |
+#    R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5
+#    OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+
+#    +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC
+#    AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=
+
+# YAML also has a set type, which looks like this:
+#set:
+#    ? item1
+#    ? item2
+#    ? item3
+
+# Like Python, sets are just maps with null values; the above is equivalent to:
+set2:
+    item1: null
+    item2: null
+    item3: null
+

--- a/lib/3rdparty/miniyaml/test/makefile
+++ b/lib/3rdparty/miniyaml/test/makefile
@@ -1,0 +1,17 @@
+test: folders ../obj/test/test.o ../obj/test/Yaml.o
+	$(CXX) -o ../bin/test ../obj/test/test.o ../obj/test/Yaml.o  -s  googletest/googletest/make/gtest_main.a -lpthread
+
+../obj/test/test.o: test.cpp
+	$(CXX) -std=c++11 -Igoogletest/googletest/include -I../yaml -c test.cpp -o ../obj/test/test.o
+
+../obj/test/Yaml.o: ../yaml/yaml.cpp
+	$(CXX) -std=c++11 -I../yaml -c ../yaml/yaml.cpp -o ../obj/test/Yaml.o
+
+folders:
+	mkdir -p ../bin
+	mkdir -p ../obj/test
+	
+
+.PHONY: clean
+clean:
+	rm -r ../obj

--- a/lib/3rdparty/miniyaml/test/test.cpp
+++ b/lib/3rdparty/miniyaml/test/test.cpp
@@ -1,0 +1,765 @@
+#include "gtest/gtest.h"
+#include "../yaml/yaml.hpp"
+#include <iostream>
+#include <fstream>
+
+/*
+Yaml 1.0 spec notes:
+
+*   Multi-line scalars with no token"|(+-) <(+-)" has not newline in end or after each row(uses spaces).
+    |   token = 1 newline.
+    |-  token = 0 newlines.
+    |+  token = 2 newlines.
+    >   token, same as | but with spaces instead of newlines after each row.
+
+* An escaped newline is ignored. \ = last character of line.
+
+*/
+
+TEST(Exception, throw)
+{
+    {
+        try
+        {
+            throw Yaml::InternalException("internal");
+        }
+        catch(const Yaml::Exception & e)
+        {
+            EXPECT_EQ(e.Type(), Yaml::Exception::InternalError);
+            EXPECT_STREQ(e.what(), "internal");
+            EXPECT_STREQ(e.Message(), "internal");
+        }
+    }
+    {
+        try
+        {
+            throw Yaml::ParsingException("parsing");
+        }
+        catch(const Yaml::Exception & e)
+        {
+            EXPECT_EQ(e.Type(), Yaml::Exception::ParsingError);
+            EXPECT_STREQ(e.what(), "parsing");
+            EXPECT_STREQ(e.Message(), "parsing");
+        }
+    }
+    {
+        try
+        {
+            throw Yaml::OperationException("operation");
+        }
+        catch(const Yaml::Exception & e)
+        {
+            EXPECT_EQ(e.Type(), Yaml::Exception::OperationError);
+            EXPECT_STREQ(e.what(), "operation");
+            EXPECT_STREQ(e.Message(), "operation");
+        }
+    }
+}
+
+TEST(Node, Type)
+{
+    {
+        Yaml::Node node;
+        EXPECT_EQ(node.Type(), Yaml::Node::None);
+        EXPECT_TRUE(node.IsNone());
+        EXPECT_FALSE(node.IsSequence());
+        EXPECT_FALSE(node.IsMap());
+        EXPECT_FALSE(node.IsScalar());
+        node.Clear();
+        EXPECT_EQ(node.Type(), Yaml::Node::None);
+    }
+    {
+        Yaml::Node node = "test";
+        EXPECT_EQ(node.Type(), Yaml::Node::ScalarType);
+        EXPECT_FALSE(node.IsNone());
+        EXPECT_FALSE(node.IsSequence());
+        EXPECT_FALSE(node.IsMap());
+        EXPECT_TRUE(node.IsScalar());
+        node.Clear();
+        EXPECT_EQ(node.Type(), Yaml::Node::None);
+    }
+    {
+        Yaml::Node node;
+        node.PushBack();
+        EXPECT_EQ(node.Type(), Yaml::Node::SequenceType);
+        EXPECT_FALSE(node.IsNone());
+        EXPECT_TRUE(node.IsSequence());
+        EXPECT_FALSE(node.IsMap());
+        EXPECT_FALSE(node.IsScalar());
+        node.Clear();
+        EXPECT_EQ(node.Type(), Yaml::Node::None);
+    }
+    {
+        Yaml::Node node;
+        node["test"];
+        EXPECT_EQ(node.Type(), Yaml::Node::MapType);
+        EXPECT_FALSE(node.IsNone());
+        EXPECT_FALSE(node.IsSequence());
+        EXPECT_TRUE(node.IsMap());
+        EXPECT_FALSE(node.IsScalar());
+        node.Clear();
+        EXPECT_EQ(node.Type(), Yaml::Node::None);
+    }
+}
+
+TEST(Node, As)
+{
+    {
+        Yaml::Node node = "Hello world!";
+        EXPECT_EQ(node.As<std::string>(), "Hello world!");
+        node = std::string("Foo bar.");
+        EXPECT_EQ(node.As<std::string>(), "Foo bar.");
+        node = std::string("");
+        EXPECT_EQ(node.As<std::string>("empty"), "empty");
+    }
+    {
+        Yaml::Node node = "123456";
+        EXPECT_EQ(node.As<int>(), 123456);
+        node = "-123456";
+        EXPECT_EQ(node.As<int>(), -123456);
+        node = "invalid";
+        EXPECT_EQ(node.As<int>(123), 123);
+    }
+    {
+        Yaml::Node node = "123.45";
+        EXPECT_EQ(node.As<float>(), 123.45f);
+        EXPECT_EQ(node.As<int>(), 123);
+        node = "-123.45";
+        EXPECT_EQ(node.As<float>(), -123.45f);
+        EXPECT_EQ(node.As<int>(), -123);
+        node = "invalid";
+        EXPECT_EQ(node.As<float>(999.1f), 999.1f);
+    }
+}
+
+TEST(Node, Size)
+{
+    {
+        Yaml::Node node;
+        EXPECT_EQ(node.Size(), 0);
+        node.PushBack();
+        EXPECT_EQ(node.Size(), 1);
+        node.PushBack();
+        EXPECT_EQ(node.Size(), 2);
+        node.Erase(1);
+        EXPECT_EQ(node.Size(), 1);
+        node.Erase(0);
+        EXPECT_EQ(node.Size(), 0);
+
+        node.Insert(10);
+        EXPECT_EQ(node.Size(), 1);
+        node.Erase(1);
+        EXPECT_EQ(node.Size(), 1);
+        node.Erase(0);
+        EXPECT_EQ(node.Size(), 0);
+
+        node.PushBack();
+        node.PushBack();
+        node.Clear();
+        EXPECT_EQ(node.Size(), 0);
+    }
+    {
+        Yaml::Node node;
+        EXPECT_EQ(node.Size(), 0);
+        node["test"];
+        EXPECT_EQ(node.Size(), 1);
+        node["test"];
+
+        EXPECT_EQ(node.Size(), 1);
+        node["foo bar"];
+        EXPECT_EQ(node.Size(), 2);
+
+        node.Erase("hello world");
+        EXPECT_EQ(node.Size(), 2);
+
+        node.Erase("test");
+        EXPECT_EQ(node.Size(), 1);
+        node.Erase("foo bar");
+        EXPECT_EQ(node.Size(), 0);
+
+        node["foo bar"];
+        EXPECT_EQ(node.Size(), 1);
+        node.Clear();
+        EXPECT_EQ(node.Size(), 0);
+    }
+    {
+        Yaml::Node node = "test";
+        EXPECT_EQ(node.Size(), 0);
+    }
+}
+
+void Compare_Node_Copy(Yaml::Node & node)
+{
+    EXPECT_TRUE(node.IsSequence());
+    EXPECT_EQ(node.Size(), 3);
+
+
+    Yaml::Node & item_1 = node[0];
+    EXPECT_TRUE(item_1.IsScalar());
+    EXPECT_EQ(item_1.As<std::string>(), "item 1");
+
+    {
+        Yaml::Node & item_2 = node[1];
+        EXPECT_TRUE(item_2.IsMap());
+        EXPECT_EQ(item_2.Size(), 1);
+
+        Yaml::Node & key = item_2["key"];
+        EXPECT_TRUE(key.IsSequence());
+        EXPECT_EQ(key.Size(), 2);
+
+        Yaml::Node & item_2_1 = key[0];
+        EXPECT_TRUE(item_2_1.IsScalar());
+        EXPECT_EQ(item_2_1.As<std::string>(), "item 2.1");
+
+        Yaml::Node & item_2_2 = key[1];
+        EXPECT_TRUE(item_2_2.IsMap());
+        EXPECT_EQ(item_2_2.Size(), 1);
+
+        Yaml::Node & key_two = item_2_2["key two"];
+        EXPECT_TRUE(key_two.IsScalar());
+        EXPECT_EQ(key_two.As<std::string>(), "item 2.2");
+    }
+
+    Yaml::Node & item_3 = node[2];
+    EXPECT_TRUE(item_3.IsScalar());
+    EXPECT_EQ(item_3.As<std::string>(), "item 3");
+}
+
+TEST(Node, Copy_1)
+{
+    {
+        Yaml::Node root;
+        root["key 1"] = "value 1";
+        root["key 2"] = "value 2";
+        root["key 3"] = "value 3";
+
+        {
+            Yaml::Node copy(root);
+
+            EXPECT_TRUE(copy.IsMap());
+
+            Yaml::Node & key_1 = copy["key 1"];
+            EXPECT_TRUE(key_1.IsScalar());
+            EXPECT_EQ(key_1.As<std::string>(), "value 1");
+
+            Yaml::Node & key_2 = copy["key 2"];
+            EXPECT_TRUE(key_2.IsScalar());
+            EXPECT_EQ(key_2.As<std::string>(), "value 2");
+
+            Yaml::Node & key_3 = copy["key 3"];
+            EXPECT_TRUE(key_3.IsScalar());
+            EXPECT_EQ(key_3.As<std::string>(), "value 3");
+        }
+    }
+
+    {
+        Yaml::Node root;
+        root.PushBack() = "item 1";
+        root.PushBack() = "item 2";
+        root.PushBack() = "item 3";
+
+        {
+            Yaml::Node copy(root);
+
+            EXPECT_TRUE(copy.IsSequence());
+            EXPECT_EQ(copy.Size(), 3);
+
+            Yaml::Node & item_1 = copy[0];
+            EXPECT_TRUE(item_1.IsScalar());
+            EXPECT_EQ(item_1.As<std::string>(), "item 1");
+
+            Yaml::Node & item_2 = copy[1];
+            EXPECT_TRUE(item_2.IsScalar());
+            EXPECT_EQ(item_2.As<std::string>(), "item 2");
+
+            Yaml::Node & item_3 = copy[2];
+            EXPECT_TRUE(item_3.IsScalar());
+            EXPECT_EQ(item_3.As<std::string>(), "item 3");
+        }
+    }
+
+    {
+        Yaml::Node root;
+        root.PushBack() = "item 1";
+        Yaml::Node & map = root.PushBack()["key"];
+        map.PushBack() = "item 2.1";
+        map.PushBack()["key two"] = "item 2.2";
+        root.PushBack() = "item 3";
+
+        {
+            Yaml::Node copy(root);
+            Compare_Node_Copy(copy);
+        }
+
+        {
+            Yaml::Node assign;
+            assign = root;
+            Compare_Node_Copy(assign);
+        }
+    }
+}
+
+void Parse_File_learnyaml(Yaml::Node & root)
+{
+    Yaml::Node & key = root["key"];
+    EXPECT_TRUE(key.IsScalar());
+    EXPECT_EQ(key.As<std::string>(), "value");
+
+    Yaml::Node & another_key = root["another_key"];
+    EXPECT_TRUE(another_key.IsScalar());
+    EXPECT_EQ(another_key.As<std::string>(), "Another value goes here.");
+
+    Yaml::Node & a_number_value = root["a_number_value"];
+    EXPECT_TRUE(a_number_value.IsScalar());
+    EXPECT_EQ(a_number_value.As<int>(), 100);
+
+    Yaml::Node & scientific_notation = root["scientific_notation"];
+    EXPECT_TRUE(scientific_notation.IsScalar());
+    EXPECT_EQ(scientific_notation.As<std::string>(), "1e+12");
+
+    Yaml::Node & boolean = root["boolean"];
+    EXPECT_TRUE(boolean.IsScalar());
+    EXPECT_EQ(boolean.As<std::string>(), "true");
+    EXPECT_EQ(boolean.As<bool>(), true);
+
+    // Null values are handled as strings.
+    Yaml::Node & null_value = root["null_value"];
+    EXPECT_TRUE(null_value.IsScalar());
+    EXPECT_EQ(null_value.As<std::string>(), "null");
+
+    Yaml::Node & key_with_spaces = root["key with spaces"];
+    EXPECT_TRUE(key_with_spaces.IsScalar());
+    EXPECT_EQ(key_with_spaces.As<std::string>(), "value");
+
+    Yaml::Node & keys_can_be_quoted_too = root["Keys: can be \"quoted\" too."];
+    EXPECT_TRUE(keys_can_be_quoted_too.IsScalar());
+    EXPECT_EQ(keys_can_be_quoted_too.As<std::string>(), "Useful if you want to put a ':' in your key. Or use comment char(#).");
+
+    Yaml::Node & scalar_block = root["scalar_block"];
+    EXPECT_TRUE(scalar_block.IsScalar());
+    EXPECT_EQ(scalar_block.As<std::string>(), "block of text will separate all lines with spaces.");
+
+    Yaml::Node & literal_block = root["literal_block"];
+    EXPECT_TRUE(literal_block.IsScalar());
+    EXPECT_EQ(literal_block.As<std::string>(),  "This entire block of text will be the value of the 'literal_block' key,      \n"
+                                                "with line breaks being preserved.\n\n"
+                                                "The literal continues until de-dented, and the leading indentation is\n"
+                                                "stripped.\n\n"
+                                                "    Any lines that are 'more-indented' keep the rest of their indentation -\n"
+                                                "    these lines will be indented by 4 spaces.\n");
+
+    Yaml::Node & folded_style = root["folded_style"];
+    EXPECT_TRUE(folded_style.IsScalar());
+    EXPECT_EQ(folded_style.As<std::string>(),   "This entire block of text will be the value of 'folded_style', but this time, all newlines will be replaced with a single space.\n"
+                                                "Blank lines, like above, are converted to a newline character.\n\n"
+                                                "    'More-indented' lines keep their newlines, too -\n"
+                                                "    this text will appear over two lines.\n");
+
+    {
+        Yaml::Node & a_nested_map = root["a_nested_map"];
+        EXPECT_TRUE(a_nested_map.IsMap());
+        EXPECT_EQ(a_nested_map.Size(), 3);
+
+        Yaml::Node & key = a_nested_map["key"];
+        EXPECT_TRUE(key.IsScalar());
+        EXPECT_EQ(key.As<std::string>(), "value");
+
+        Yaml::Node & another_key = a_nested_map["another_key"];
+        EXPECT_TRUE(another_key.IsScalar());
+        EXPECT_EQ(another_key.As<std::string>(), "Another Value");
+
+        Yaml::Node & another_nested_map = a_nested_map["another_nested_map"];
+        EXPECT_TRUE(another_nested_map.IsMap());
+        EXPECT_EQ(another_nested_map.Size(), 1);
+
+        Yaml::Node & hello = another_nested_map["hello"];
+        EXPECT_TRUE(hello.IsScalar());
+        EXPECT_EQ(hello.As<std::string>(), "hello");
+    }
+
+    // Not allowing floats as keys, read as string.
+    Yaml::Node & point_twenty_five = root["0.25"];
+    EXPECT_TRUE(point_twenty_five.IsScalar());
+    EXPECT_EQ(point_twenty_five.As<std::string>(), "a float key");
+
+    {
+        Yaml::Node & a_sequence = root["a_sequence"];
+        EXPECT_TRUE(a_sequence.IsSequence());
+        EXPECT_EQ(a_sequence.Size(), 6);
+
+        Yaml::Node & item_1 = a_sequence[0];
+        EXPECT_TRUE(item_1.IsScalar());
+        EXPECT_EQ(item_1.As<std::string>(), "Item 1");
+
+        Yaml::Node & item_2 = a_sequence[1];
+        EXPECT_TRUE(item_2.IsScalar());
+        EXPECT_EQ(item_2.As<std::string>(), "Item 2");
+
+        Yaml::Node & item_3 = a_sequence[2];
+        EXPECT_TRUE(item_3.IsScalar());
+        EXPECT_EQ(item_3.As<std::string>(), "0.5");
+        EXPECT_EQ(item_3.As<float>(), 0.5f);
+
+        Yaml::Node & item_4 = a_sequence[3];
+        EXPECT_TRUE(item_4.IsScalar());
+        EXPECT_EQ(item_4.As<std::string>(), "Item 4");
+
+        Yaml::Node & item_5 = a_sequence[4];
+        EXPECT_TRUE(item_5.IsMap());
+        EXPECT_EQ(item_5.Size(), 2);
+
+        Yaml::Node & key = item_5["key"];
+        EXPECT_TRUE(key.IsScalar());
+        EXPECT_EQ(key.As<std::string>(), "value");
+
+        Yaml::Node & another_key = item_5["another_key"];
+        EXPECT_TRUE(another_key.IsScalar());
+        EXPECT_EQ(another_key.As<std::string>(), "another_value");
+
+        Yaml::Node & item_6 = a_sequence[5];
+        EXPECT_TRUE(item_6.IsSequence());
+        EXPECT_EQ(item_6.Size(), 2);
+
+        Yaml::Node & item_6_1 = item_6[0];
+        EXPECT_TRUE(item_6_1.IsScalar());
+        EXPECT_EQ(item_6_1.As<std::string>(), "This is a sequence");
+
+        Yaml::Node & item_6_2 = item_6[1];
+        EXPECT_TRUE(item_6_2.IsScalar());
+        EXPECT_EQ(item_6_2.As<std::string>(), "inside another sequence");
+    }
+
+    Yaml::Node & datetime = root["datetime"];
+    EXPECT_TRUE(datetime.IsScalar());
+    EXPECT_EQ(datetime.As<std::string>(), "2001-12-15T02:59:43.1Z");
+
+    Yaml::Node & datetime_with_spaces = root["datetime_with_spaces"];
+    EXPECT_TRUE(datetime_with_spaces.IsScalar());
+    EXPECT_EQ(datetime_with_spaces.As<std::string>(), "2001-12-14 21:59:43.10 -5");
+
+    Yaml::Node & date = root["date"];
+    EXPECT_TRUE(date.IsScalar());
+    EXPECT_EQ(date.As<std::string>(), "2002-12-14");
+
+    {
+        Yaml::Node & set2 = root["set2"];
+        EXPECT_TRUE(set2.IsMap());
+        EXPECT_EQ(set2.Size(), 3);
+
+        Yaml::Node & item1 = set2["item1"];
+        EXPECT_TRUE(item1.IsScalar());
+        EXPECT_EQ(item1.As<std::string>(), "null");
+
+        Yaml::Node & item2 = set2["item2"];
+        EXPECT_TRUE(item2.IsScalar());
+        EXPECT_EQ(item2.As<std::string>(), "null");
+
+        Yaml::Node & item3 = set2["item3"];
+        EXPECT_TRUE(item3.IsScalar());
+        EXPECT_EQ(item3.As<std::string>(), "null");
+    }
+}
+
+TEST(Node, Copy_2)
+{
+
+    Yaml::Node root;
+    EXPECT_NO_THROW(Yaml::Parse(root, "../test/learnyaml.yaml"));
+
+    {
+        Yaml::Node copy(root);
+        Parse_File_learnyaml(copy);
+    }
+    {
+        Yaml::Node copy = root;
+        Parse_File_learnyaml(copy);
+    }
+
+
+}
+
+TEST(Parse, File)
+{
+    {
+        Yaml::Node root;
+        EXPECT_THROW(Yaml::Parse(root, "bad_path_of_file.txt"), Yaml::OperationException);
+    }
+    {
+        Yaml::Node root;
+        EXPECT_NO_THROW(Yaml::Parse(root, "../.travis.yml"));
+    }
+    {
+        Yaml::Node root;
+        EXPECT_THROW(Yaml::Parse(root, "../yaml/yaml.hpp"), Yaml::ParsingException);
+    }
+    {
+        Yaml::Node root;
+        EXPECT_NO_THROW(Yaml::Parse(root, "../test/learnyaml.yaml"));
+    }
+}
+
+TEST(Parse, File_learnyaml)
+{
+    const std::string filename = "../test/learnyaml.yaml";
+
+    {
+        Yaml::Node root;
+        EXPECT_NO_THROW(Yaml::Parse(root, filename.c_str()));
+
+        Parse_File_learnyaml(root);
+    }
+    {
+        std::ifstream fin(filename, std::ifstream::binary);
+        EXPECT_TRUE(fin.is_open());
+        if(fin.is_open())
+        {
+            fin.seekg(0, fin.end);
+            size_t dataSize = static_cast<size_t>(fin.tellg());
+            fin.seekg(0, fin.beg);
+            char * pData = new char [dataSize];
+            fin.read(pData, dataSize);
+            fin.close();
+
+            Yaml::Node root;
+            EXPECT_NO_THROW(Yaml::Parse(root, pData, dataSize));
+            delete [] pData;
+            Parse_File_learnyaml(root);
+        }
+    }
+    {
+        std::ifstream fin(filename, std::ifstream::binary);
+        EXPECT_TRUE(fin.is_open());
+        if(fin.is_open())
+        {
+            fin.seekg(0, fin.end);
+            size_t dataSize = static_cast<size_t>(fin.tellg());
+            fin.seekg(0, fin.beg);
+            char * pData = new char [dataSize];
+            fin.read(pData, dataSize);
+            fin.close();
+            std::string data(pData, dataSize);
+            delete [] pData;
+
+            // String
+            Yaml::Node root_string;
+            EXPECT_NO_THROW(Yaml::Parse(root_string, data));
+            Parse_File_learnyaml(root_string);
+
+            // Stream
+            std::stringstream stream(data);
+            Yaml::Node root_stream;
+            EXPECT_NO_THROW(Yaml::Parse(root_stream, stream));
+            Parse_File_learnyaml(root_stream);
+        }
+    }
+}
+
+TEST(Parse, Invalid)
+{
+    std::ifstream fin("../test/invalid.yaml", std::ifstream::binary);
+    EXPECT_TRUE(fin.is_open());
+    if(fin.is_open())
+    {
+        fin.seekg(0, fin.end);
+        size_t dataSize = static_cast<size_t>(fin.tellg());
+        fin.seekg(0, fin.beg);
+        char * pData = new char [dataSize];
+        fin.read(pData, dataSize);
+        fin.close();
+        std::string data(pData, dataSize);
+        delete [] pData;
+        std::stringstream stream(data);
+        Yaml::Node root_stream;
+
+        const size_t tests = 8;
+        size_t loops = 0;
+        while(loops < tests)
+        {
+            loops++;
+
+            //try
+            //{
+            //    Yaml::Parse(root_stream, stream);
+            //}
+            //catch(const Yaml::Exception & e)
+            //{
+            //    std::cout << "Exception(" << e.Type() <<  "): " << e.what() << std::endl;
+            //}
+
+            EXPECT_THROW(Yaml::Parse(root_stream, stream), Yaml::ParsingException);
+
+        }
+    }
+}
+
+TEST(Parse, Valid)
+{
+    std::ifstream fin("../test/valid.yaml", std::ifstream::binary);
+    EXPECT_TRUE(fin.is_open());
+    if(fin.is_open())
+    {
+        fin.seekg(0, fin.end);
+        size_t dataSize = static_cast<size_t>(fin.tellg());
+        fin.seekg(0, fin.beg);
+        char * pData = new char [dataSize];
+        fin.read(pData, dataSize);
+        fin.close();
+        std::string data(pData, dataSize);
+        delete [] pData;
+        std::stringstream stream(data);
+        Yaml::Node root_stream;
+
+        const size_t tests = 8;
+        size_t loops = 0;
+        while(loops < tests)
+        {
+            loops++;
+
+            //try
+            //{
+            //    Yaml::Parse(root_stream, stream);
+            //}
+            //catch(const Yaml::Exception & e)
+            //{
+            //    std::cout << "Exception(" << e.Type() <<  "): " << e.what() << std::endl;
+            //}
+
+            EXPECT_NO_THROW(Yaml::Parse(root_stream, stream));
+
+        }
+    }
+}
+
+TEST(Iterator, Iterator)
+{
+    Yaml::Node root;
+    root["key"] = "value";
+    root["another_key"] = "Another Value";
+    root["another_nested_map"]["key"] = "value";
+
+    EXPECT_TRUE(root.IsMap());
+    EXPECT_EQ(root.Size(), 3);
+
+    size_t loops = 0;
+    bool flags[3] = {false, false, false};
+    for(Yaml::Iterator it = root.Begin(); it != root.End(); it++)
+    {
+        std::pair<std::string, Yaml::Node&> value = *it;
+        const std::string & key = value.first;
+
+        if(key == "key")
+        {
+            Yaml::Node & node = value.second;
+            EXPECT_TRUE(node.IsScalar());
+            EXPECT_EQ(node.As<std::string>(), "value");
+            flags[0] = true;
+        }
+        else if(key == "another_key")
+        {
+            Yaml::Node & node = value.second;
+            EXPECT_TRUE(node.IsScalar());
+            EXPECT_EQ(node.As<std::string>(), "Another Value");
+            flags[1] = true;
+        }
+        else if(key == "another_nested_map")
+        {
+            Yaml::Node & node = value.second;
+            EXPECT_TRUE(node.IsMap());
+            flags[2] = true;
+        }
+
+        loops++;
+    }
+
+    EXPECT_EQ(loops, 3);
+    EXPECT_TRUE(flags[0]);
+    EXPECT_TRUE(flags[1]);
+    EXPECT_TRUE(flags[2]);
+
+}
+
+TEST(Iterator, ConstIterator)
+{
+    Yaml::Node root;
+    root["key"] = "value";
+    root["another_key"] = "Another Value";
+    root["another_nested_map"]["key"] = "value";
+    const Yaml::Node & constRoot = root;;
+
+
+    EXPECT_TRUE(constRoot.IsMap());
+    EXPECT_EQ(constRoot.Size(), 3);
+
+    size_t loops = 0;
+    bool flags[3] = {false, false, false};
+    for(Yaml::ConstIterator it = constRoot.Begin(); it != constRoot.End(); it++)
+    {
+        std::pair<std::string, const Yaml::Node&> value = *it;
+        const std::string & key = value.first;
+
+        if(key == "key")
+        {
+            const Yaml::Node & node = value.second;
+            EXPECT_TRUE(node.IsScalar());
+            EXPECT_EQ(node.As<std::string>(), "value");
+            flags[0] = true;
+        }
+        else if(key == "another_key")
+        {
+            const Yaml::Node & node = value.second;
+            EXPECT_TRUE(node.IsScalar());
+            EXPECT_EQ(node.As<std::string>(), "Another Value");
+            flags[1] = true;
+        }
+        else if(key == "another_nested_map")
+        {
+            const Yaml::Node & node = value.second;
+            EXPECT_TRUE(node.IsMap());
+            flags[2] = true;
+        }
+
+        loops++;
+    }
+
+    EXPECT_EQ(loops, 3);
+    EXPECT_TRUE(flags[0]);
+    EXPECT_TRUE(flags[1]);
+    EXPECT_TRUE(flags[2]);
+}
+
+TEST(Serialize, Serialize)
+{
+    Yaml::Node root;
+    EXPECT_NO_THROW(Yaml::Parse(root, "../test/learnyaml.yaml"));
+
+    {
+        EXPECT_NO_THROW(Yaml::Serialize(root, "test_learnyaml.yaml"));
+
+        Yaml::Node learn_yaml;
+        EXPECT_NO_THROW(Yaml::Parse(learn_yaml, "test_learnyaml.yaml"));
+        Parse_File_learnyaml(learn_yaml);
+    }
+    {
+        std::string data = "";
+        EXPECT_NO_THROW(Yaml::Serialize(root, data));
+
+        Yaml::Node learn_yaml;
+        EXPECT_NO_THROW(Yaml::Parse(learn_yaml, data));
+        Parse_File_learnyaml(learn_yaml);
+    }
+    {
+        std::stringstream data;
+        EXPECT_NO_THROW(Yaml::Serialize(root, data));
+
+        Yaml::Node learn_yaml;
+        EXPECT_NO_THROW(Yaml::Parse(learn_yaml, data));
+        Parse_File_learnyaml(learn_yaml);
+    }
+}
+
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/lib/3rdparty/miniyaml/test/valid.yaml
+++ b/lib/3rdparty/miniyaml/test/valid.yaml
@@ -1,0 +1,32 @@
+#Scalar tests
+---
+key: foo
+     bar
+
+---
+key: "val\"ue"
+
+---
+key: "value\""
+
+---
+foo
+bar
+
+---
+"foo
+bar"
+
+---
+"foo\"
+\"bar"
+
+---
+foo
+    bar
+
+---
+|
+ foo
+ bar
+

--- a/lib/3rdparty/miniyaml/visualstudio/2017/Examples.sln
+++ b/lib/3rdparty/miniyaml/visualstudio/2017/Examples.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2009
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FirstExample", "FirstExample.vcxproj", "{0C8D8223-94A0-4E70-B672-FC053975D3B9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0C8D8223-94A0-4E70-B672-FC053975D3B9}.Debug|x64.ActiveCfg = Debug|x64
+		{0C8D8223-94A0-4E70-B672-FC053975D3B9}.Debug|x64.Build.0 = Debug|x64
+		{0C8D8223-94A0-4E70-B672-FC053975D3B9}.Debug|x86.ActiveCfg = Debug|Win32
+		{0C8D8223-94A0-4E70-B672-FC053975D3B9}.Debug|x86.Build.0 = Debug|Win32
+		{0C8D8223-94A0-4E70-B672-FC053975D3B9}.Release|x64.ActiveCfg = Release|x64
+		{0C8D8223-94A0-4E70-B672-FC053975D3B9}.Release|x64.Build.0 = Release|x64
+		{0C8D8223-94A0-4E70-B672-FC053975D3B9}.Release|x86.ActiveCfg = Release|Win32
+		{0C8D8223-94A0-4E70-B672-FC053975D3B9}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {58869F11-D1D6-4ADB-BCD2-A2243555887C}
+	EndGlobalSection
+EndGlobal

--- a/lib/3rdparty/miniyaml/visualstudio/2017/FirstExample.vcxproj
+++ b/lib/3rdparty/miniyaml/visualstudio/2017/FirstExample.vcxproj
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\examples\FirstExample.cpp" />
+    <ClCompile Include="..\..\yaml\yaml.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\yaml\yaml.hpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{0C8D8223-94A0-4E70-B672-FC053975D3B9}</ProjectGuid>
+    <RootNamespace>Example</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>..\..\bin\</OutDir>
+    <IntDir>..\..\obj\x86\debug</IntDir>
+    <TargetName>$(ProjectName)-d</TargetName>
+    <IncludePath>..\..\yaml;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>..\..\bin</OutDir>
+    <IntDir>..\..\obj\x86\release</IntDir>
+    <IncludePath>..\..\yaml;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>..\..\bin</OutDir>
+    <IntDir>..\..\obj\x64\release</IntDir>
+    <TargetName>$(ProjectName)-x64</TargetName>
+    <IncludePath>..\..\yaml;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>..\..\bin\</OutDir>
+    <IntDir>..\..\obj\x64\debug</IntDir>
+    <TargetName>$(ProjectName)-x64-d</TargetName>
+    <IncludePath>..\..\yaml;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/lib/3rdparty/miniyaml/yaml/yaml.cpp
+++ b/lib/3rdparty/miniyaml/yaml/yaml.cpp
@@ -1,0 +1,2774 @@
+/*
+* MIT License
+*
+* Copyright(c) 2018 Jimmie Bergmann
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files(the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions :
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+*/
+
+#include "yaml.hpp"
+#include <memory>
+#include <fstream>
+#include <sstream>
+#include <vector>
+#include <list>
+#include <cstdio>
+#include <stdarg.h>
+
+
+// Implementation access definitions.
+#define NODE_IMP static_cast<NodeImp*>(m_pImp)
+#define NODE_IMP_EXT(node) static_cast<NodeImp*>(node.m_pImp)
+#define TYPE_IMP static_cast<NodeImp*>(m_pImp)->m_pImp
+
+
+#define IT_IMP static_cast<IteratorImp*>(m_pImp)
+
+
+namespace Yaml
+{
+    class ReaderLine;
+
+    // Exception message definitions.
+    static const std::string g_ErrorInvalidCharacter        = "Invalid character found.";
+    static const std::string g_ErrorKeyMissing              = "Missing key.";
+    static const std::string g_ErrorKeyIncorrect            = "Incorrect key.";
+    static const std::string g_ErrorValueIncorrect          = "Incorrect value.";
+    static const std::string g_ErrorTabInOffset             = "Tab found in offset.";
+    static const std::string g_ErrorBlockSequenceNotAllowed = "Sequence entries are not allowed in this context.";
+    static const std::string g_ErrorUnexpectedDocumentEnd   = "Unexpected document end.";
+    static const std::string g_ErrorDiffEntryNotAllowed     = "Different entry is not allowed in this context.";
+    static const std::string g_ErrorIncorrectOffset         = "Incorrect offset.";
+    static const std::string g_ErrorSequenceError           = "Error in sequence node.";
+    static const std::string g_ErrorCannotOpenFile          = "Cannot open file.";
+    static const std::string g_ErrorIndentation             = "Space indentation is less than 2.";
+    static const std::string g_ErrorInvalidBlockScalar      = "Invalid block scalar.";
+    static const std::string g_ErrorInvalidQuote            = "Invalid quote.";
+    static const std::string g_EmptyString                  = "";
+    static Yaml::Node        g_NoneNode;
+
+    // Global function definitions. Implemented at end of this source file.
+    static std::string ExceptionMessage(const std::string & message, ReaderLine & line);
+    static std::string ExceptionMessage(const std::string & message, ReaderLine & line, const size_t errorPos);
+    static std::string ExceptionMessage(const std::string & message, const size_t errorLine, const size_t errorPos);
+    static std::string ExceptionMessage(const std::string & message, const size_t errorLine, const std::string & data);
+
+    static bool FindQuote(const std::string & input, size_t & start, size_t & end, size_t searchPos = 0);
+    static size_t FindNotCited(const std::string & input, char token, size_t & preQuoteCount);
+    static size_t FindNotCited(const std::string & input, char token);
+    static bool ValidateQuote(const std::string & input);
+    static void CopyNode(const Node & from, Node & to);
+    static bool ShouldBeCited(const std::string & key);
+    static void AddEscapeTokens(std::string & input, const std::string & tokens);
+    static void RemoveAllEscapeTokens(std::string & input);
+
+    // Exception implementations
+    Exception::Exception(const std::string & message, const eType type) :
+        std::runtime_error(message),
+        m_Type(type)
+    {
+    }
+
+    Exception::eType Exception::Type() const
+    {
+        return m_Type;
+    }
+
+    const char * Exception::Message() const
+    {
+        return what();
+    }
+
+    InternalException::InternalException(const std::string & message) :
+        Exception(message, InternalError)
+    {
+
+    }
+
+    ParsingException::ParsingException(const std::string & message) :
+        Exception(message, ParsingError)
+    {
+
+    }
+
+    OperationException::OperationException(const std::string & message) :
+        Exception(message, OperationError)
+    {
+
+    }
+
+
+    class TypeImp
+    {
+
+    public:
+
+        virtual ~TypeImp()
+        {
+        }
+
+        virtual const std::string & GetData() const = 0;
+        virtual bool SetData(const std::string & data) = 0;
+        virtual size_t GetSize() const = 0;
+        virtual Node * GetNode(const size_t index) = 0;
+        virtual Node * GetNode(const std::string & key) = 0;
+        virtual Node * Insert(const size_t index) = 0;
+        virtual Node * PushFront() = 0;
+        virtual Node * PushBack() = 0;
+        virtual void Erase(const size_t index) = 0;
+        virtual void Erase(const std::string & key) = 0;
+
+    };
+
+    class SequenceImp : public TypeImp
+    {
+
+    public:
+
+        ~SequenceImp()
+        {
+            for(auto it = m_Sequence.begin(); it != m_Sequence.end(); it++)
+            {
+                delete it->second;
+            }
+        }
+
+        virtual const std::string & GetData() const
+        {
+            return g_EmptyString;
+        }
+
+        virtual bool SetData(const std::string & data)
+        {
+            return false;
+        }
+
+        virtual size_t GetSize() const
+        {
+            return m_Sequence.size();
+        }
+
+        virtual Node * GetNode(const size_t index)
+        {
+            auto it = m_Sequence.find(index);
+            if(it != m_Sequence.end())
+            {
+                return it->second;
+            }
+            return nullptr;
+        }
+
+        virtual Node * GetNode(const std::string & key)
+        {
+            return nullptr;
+        }
+
+        virtual Node * Insert(const size_t index)
+        {
+            if(m_Sequence.size() == 0)
+            {
+                Node * pNode = new Node;
+                m_Sequence.insert({0, pNode});
+                return pNode;
+            }
+
+            if(index >= m_Sequence.size())
+            {
+                auto it = m_Sequence.end();
+                --it;
+                Node * pNode = new Node;
+                m_Sequence.insert({it->first, pNode});
+                return pNode;
+            }
+
+            auto it = m_Sequence.cbegin();
+            while(it != m_Sequence.cend())
+            {
+                m_Sequence[it->first+1] = it->second;
+
+                if(it->first == index)
+                {
+                    break;
+                }
+            }
+
+            Node * pNode = new Node;
+            m_Sequence.insert({index, pNode});
+            return pNode;
+        }
+
+        virtual Node * PushFront()
+        {
+            for(auto it = m_Sequence.cbegin(); it != m_Sequence.cend(); it++)
+            {
+                m_Sequence[it->first+1] = it->second;
+            }
+
+            Node * pNode = new Node;
+            m_Sequence.insert({0, pNode});
+            return pNode;
+        }
+
+        virtual Node * PushBack()
+        {
+            size_t index = 0;
+            if(m_Sequence.size())
+            {
+                auto it = m_Sequence.end();
+                --it;
+                index = it->first + 1;
+            }
+
+            Node * pNode = new Node;
+            m_Sequence.insert({index, pNode});
+            return pNode;
+        }
+
+        virtual void Erase(const size_t index)
+        {
+            auto it = m_Sequence.find(index);
+            if(it == m_Sequence.end())
+            {
+                return;
+            }
+            delete it->second;
+            m_Sequence.erase(index);
+        }
+
+        virtual void Erase(const std::string & key)
+        {
+        }
+
+        std::map<size_t, Node*> m_Sequence;
+
+    };
+
+    class MapImp : public TypeImp
+    {
+
+    public:
+
+        ~MapImp()
+        {
+            for(auto it = m_Map.begin(); it != m_Map.end(); it++)
+            {
+                delete it->second;
+            }
+        }
+
+        virtual const std::string & GetData() const
+        {
+            return g_EmptyString;
+        }
+
+        virtual bool SetData(const std::string & data)
+        {
+            return false;
+        }
+
+        virtual size_t GetSize() const
+        {
+            return m_Map.size();
+        }
+
+        virtual Node * GetNode(const size_t index)
+        {
+            return nullptr;
+        }
+
+        virtual Node * GetNode(const std::string & key)
+        {
+            auto it = m_Map.find(key);
+            if(it == m_Map.end())
+            {
+                Node * pNode = new Node;
+                m_Map.insert({key, pNode});
+                return pNode;
+            }
+            return it->second;
+        }
+
+        virtual Node * Insert(const size_t index)
+        {
+            return nullptr;
+        }
+
+        virtual Node * PushFront()
+        {
+            return nullptr;
+        }
+
+        virtual Node * PushBack()
+        {
+            return nullptr;
+        }
+
+        virtual void Erase(const size_t index)
+        {
+        }
+
+        virtual void Erase(const std::string & key)
+        {
+            auto it = m_Map.find(key);
+            if(it == m_Map.end())
+            {
+                return;
+            }
+            delete it->second;
+            m_Map.erase(key);
+        }
+
+        std::map<std::string, Node*> m_Map;
+
+    };
+
+    class ScalarImp : public TypeImp
+    {
+
+    public:
+
+        ~ScalarImp()
+        {
+        }
+
+        virtual const std::string & GetData() const
+        {
+            return m_Value;
+        }
+
+        virtual bool SetData(const std::string & data)
+        {
+            m_Value = data;
+            return true;
+        }
+
+        virtual size_t GetSize() const
+        {
+            return 0;
+        }
+
+        virtual Node * GetNode(const size_t index)
+        {
+            return nullptr;
+        }
+
+        virtual Node * GetNode(const std::string & key)
+        {
+            return nullptr;
+        }
+
+        virtual Node * Insert(const size_t index)
+        {
+            return nullptr;
+        }
+
+        virtual Node * PushFront()
+        {
+            return nullptr;
+        }
+
+        virtual Node * PushBack()
+        {
+            return nullptr;
+        }
+
+        virtual void Erase(const size_t index)
+        {
+        }
+
+        virtual void Erase(const std::string & key)
+        {
+        }
+
+        std::string m_Value;
+
+    };
+
+
+    // Node implementations.
+    class NodeImp
+    {
+
+    public:
+
+        NodeImp() :
+            m_Type(Node::None),
+            m_pImp(nullptr)
+        {
+        }
+
+        ~NodeImp()
+        {
+            Clear();
+        }
+
+        void Clear()
+        {
+            if(m_pImp != nullptr)
+            {
+                delete m_pImp;
+                m_pImp = nullptr;
+            }
+            m_Type = Node::None;
+        }
+
+        void InitSequence()
+        {
+            if(m_Type != Node::SequenceType || m_pImp == nullptr)
+            {
+                if(m_pImp)
+                {
+                    delete m_pImp;
+                }
+                m_pImp = new SequenceImp;
+                m_Type = Node::SequenceType;
+            }
+        }
+
+        void InitMap()
+        {
+            if(m_Type != Node::MapType || m_pImp == nullptr)
+            {
+                if(m_pImp)
+                {
+                    delete m_pImp;
+                }
+                m_pImp = new MapImp;
+                m_Type = Node::MapType;
+            }
+        }
+
+        void InitScalar()
+        {
+            if(m_Type != Node::ScalarType || m_pImp == nullptr)
+            {
+                if(m_pImp)
+                {
+                    delete m_pImp;
+                }
+                m_pImp = new ScalarImp;
+                m_Type = Node::ScalarType;
+            }
+
+        }
+
+        Node::eType    m_Type;  ///< Type of node.
+        TypeImp *      m_pImp;  ///< Imp of type.
+
+    };
+
+    // Iterator implementation class
+    class IteratorImp
+    {
+
+    public:
+
+        virtual ~IteratorImp()
+        {
+        }
+
+        virtual Node::eType GetType() const = 0;
+        virtual void InitBegin(SequenceImp * pSequenceImp) = 0;
+        virtual void InitEnd(SequenceImp * pSequenceImp) = 0;
+        virtual void InitBegin(MapImp * pMapImp) = 0;
+        virtual void InitEnd(MapImp * pMapImp) = 0;
+
+    };
+
+    class SequenceIteratorImp : public IteratorImp
+    {
+
+    public:
+
+        virtual Node::eType GetType() const
+        {
+            return Node::SequenceType;
+        }
+
+        virtual void InitBegin(SequenceImp * pSequenceImp)
+        {
+            m_Iterator = pSequenceImp->m_Sequence.begin();
+        }
+
+        virtual void InitEnd(SequenceImp * pSequenceImp)
+        {
+            m_Iterator = pSequenceImp->m_Sequence.end();
+        }
+
+        virtual void InitBegin(MapImp * pMapImp)
+        {
+        }
+
+        virtual void InitEnd(MapImp * pMapImp)
+        {
+        }
+
+        void Copy(const SequenceIteratorImp & it)
+        {
+            m_Iterator = it.m_Iterator;
+        }
+
+        std::map<size_t, Node *>::iterator m_Iterator;
+
+    };
+
+    class MapIteratorImp : public IteratorImp
+    {
+
+    public:
+
+        virtual Node::eType GetType() const
+        {
+            return Node::MapType;
+        }
+
+        virtual void InitBegin(SequenceImp * pSequenceImp)
+        {
+        }
+
+        virtual void InitEnd(SequenceImp * pSequenceImp)
+        {
+        }
+
+        virtual void InitBegin(MapImp * pMapImp)
+        {
+            m_Iterator = pMapImp->m_Map.begin();
+        }
+
+        virtual void InitEnd(MapImp * pMapImp)
+        {
+            m_Iterator = pMapImp->m_Map.end();
+        }
+
+        void Copy(const MapIteratorImp & it)
+        {
+            m_Iterator = it.m_Iterator;
+        }
+
+        std::map<std::string, Node *>::iterator m_Iterator;
+
+    };
+
+    class SequenceConstIteratorImp : public IteratorImp
+    {
+
+    public:
+
+        virtual Node::eType GetType() const
+        {
+            return Node::SequenceType;
+        }
+
+        virtual void InitBegin(SequenceImp * pSequenceImp)
+        {
+            m_Iterator = pSequenceImp->m_Sequence.begin();
+        }
+
+        virtual void InitEnd(SequenceImp * pSequenceImp)
+        {
+            m_Iterator = pSequenceImp->m_Sequence.end();
+        }
+
+        virtual void InitBegin(MapImp * pMapImp)
+        {
+        }
+
+        virtual void InitEnd(MapImp * pMapImp)
+        {
+        }
+
+        void Copy(const SequenceConstIteratorImp & it)
+        {
+            m_Iterator = it.m_Iterator;
+        }
+
+        std::map<size_t, Node *>::const_iterator m_Iterator;
+
+    };
+
+    class MapConstIteratorImp : public IteratorImp
+    {
+
+    public:
+
+        virtual Node::eType GetType() const
+        {
+            return Node::MapType;
+        }
+
+        virtual void InitBegin(SequenceImp * pSequenceImp)
+        {
+        }
+
+        virtual void InitEnd(SequenceImp * pSequenceImp)
+        {
+        }
+
+        virtual void InitBegin(MapImp * pMapImp)
+        {
+            m_Iterator = pMapImp->m_Map.begin();
+        }
+
+        virtual void InitEnd(MapImp * pMapImp)
+        {
+            m_Iterator = pMapImp->m_Map.end();
+        }
+
+        void Copy(const MapConstIteratorImp & it)
+        {
+            m_Iterator = it.m_Iterator;
+        }
+
+        std::map<std::string, Node *>::const_iterator m_Iterator;
+
+    };
+
+
+    // Iterator class
+    Iterator::Iterator() :
+        m_Type(None),
+        m_pImp(nullptr)
+    {
+    }
+
+    Iterator::~Iterator()
+    {
+        if(m_pImp)
+        {
+            switch(m_Type)
+            {
+            case SequenceType:
+                delete static_cast<SequenceIteratorImp*>(m_pImp);
+                break;
+            case MapType:
+                delete static_cast<MapIteratorImp*>(m_pImp);
+                break;
+            default:
+                break;
+            }
+
+        }
+    }
+
+    Iterator::Iterator(const Iterator & it) :
+        m_Type(None),
+        m_pImp(nullptr)
+    {
+        *this = it;
+    }
+
+    Iterator & Iterator::operator = (const Iterator & it)
+    {
+        if(m_pImp)
+        {
+            switch(m_Type)
+            {
+            case SequenceType:
+                delete static_cast<SequenceIteratorImp*>(m_pImp);
+                break;
+            case MapType:
+                delete static_cast<MapIteratorImp*>(m_pImp);
+                break;
+            default:
+                break;
+            }
+            m_pImp = nullptr;
+            m_Type = None;
+        }
+
+        IteratorImp * pNewImp = nullptr;
+
+        switch(it.m_Type)
+        {
+        case SequenceType:
+            m_Type = SequenceType;
+            pNewImp = new SequenceIteratorImp;
+            static_cast<SequenceIteratorImp*>(pNewImp)->m_Iterator = static_cast<SequenceIteratorImp*>(it.m_pImp)->m_Iterator;
+            break;
+        case MapType:
+            m_Type = MapType;
+            pNewImp = new MapIteratorImp;
+            static_cast<MapIteratorImp*>(pNewImp)->m_Iterator = static_cast<MapIteratorImp*>(it.m_pImp)->m_Iterator;
+            break;
+        default:
+            break;
+        }
+
+        m_pImp = pNewImp;
+        return *this;
+    }
+
+    std::pair<const std::string &, Node &> Iterator::operator *()
+    {
+        switch(m_Type)
+        {
+        case SequenceType:
+            return { g_EmptyString, *(static_cast<SequenceIteratorImp*>(m_pImp)->m_Iterator->second)};
+            break;
+        case MapType:
+            return {static_cast<MapIteratorImp*>(m_pImp)->m_Iterator->first,
+                    *(static_cast<MapIteratorImp*>(m_pImp)->m_Iterator->second)};
+            break;
+        default:
+            break;
+        }
+
+        g_NoneNode.Clear();
+        return { g_EmptyString, g_NoneNode};
+    }
+
+    Iterator & Iterator::operator ++ (int dummy)
+    {
+        switch(m_Type)
+        {
+        case SequenceType:
+            static_cast<SequenceIteratorImp*>(m_pImp)->m_Iterator++;
+            break;
+        case MapType:
+            static_cast<MapIteratorImp*>(m_pImp)->m_Iterator++;
+            break;
+        default:
+            break;
+        }
+        return *this;
+    }
+
+    Iterator & Iterator::operator -- (int dummy)
+    {
+        switch(m_Type)
+        {
+        case SequenceType:
+            static_cast<SequenceIteratorImp*>(m_pImp)->m_Iterator--;
+            break;
+        case MapType:
+            static_cast<MapIteratorImp*>(m_pImp)->m_Iterator--;
+            break;
+        default:
+            break;
+        }
+        return *this;
+    }
+
+    bool Iterator::operator == (const Iterator & it)
+    {
+        if(m_Type != it.m_Type)
+        {
+            return false;
+        }
+
+        switch(m_Type)
+        {
+        case SequenceType:
+            return static_cast<SequenceIteratorImp*>(m_pImp)->m_Iterator == static_cast<SequenceIteratorImp*>(it.m_pImp)->m_Iterator;
+            break;
+        case MapType:
+            return static_cast<MapIteratorImp*>(m_pImp)->m_Iterator == static_cast<MapIteratorImp*>(it.m_pImp)->m_Iterator;
+            break;
+        default:
+            break;
+        }
+
+        return false;
+    }
+
+    bool Iterator::operator != (const Iterator & it)
+    {
+        return !(*this == it);
+    }
+
+
+    // Const Iterator class
+    ConstIterator::ConstIterator() :
+        m_Type(None),
+        m_pImp(nullptr)
+    {
+    }
+
+    ConstIterator::~ConstIterator()
+    {
+        if(m_pImp)
+        {
+            switch(m_Type)
+            {
+            case SequenceType:
+                delete static_cast<SequenceConstIteratorImp*>(m_pImp);
+                break;
+            case MapType:
+                delete static_cast<MapConstIteratorImp*>(m_pImp);
+                break;
+            default:
+                break;
+            }
+
+        }
+    }
+
+    ConstIterator::ConstIterator(const ConstIterator & it) :
+        m_Type(None),
+        m_pImp(nullptr)
+    {
+        *this = it;
+    }
+
+    ConstIterator & ConstIterator::operator = (const ConstIterator & it)
+    {
+        if(m_pImp)
+        {
+            switch(m_Type)
+            {
+            case SequenceType:
+                delete static_cast<SequenceConstIteratorImp*>(m_pImp);
+                break;
+            case MapType:
+                delete static_cast<MapConstIteratorImp*>(m_pImp);
+                break;
+            default:
+                break;
+            }
+            m_pImp = nullptr;
+            m_Type = None;
+        }
+
+        IteratorImp * pNewImp = nullptr;
+
+        switch(it.m_Type)
+        {
+        case SequenceType:
+            m_Type = SequenceType;
+            pNewImp = new SequenceConstIteratorImp;
+            static_cast<SequenceConstIteratorImp*>(pNewImp)->m_Iterator = static_cast<SequenceConstIteratorImp*>(it.m_pImp)->m_Iterator;
+            break;
+        case MapType:
+            m_Type = MapType;
+            pNewImp = new MapConstIteratorImp;
+            static_cast<MapConstIteratorImp*>(pNewImp)->m_Iterator = static_cast<MapConstIteratorImp*>(it.m_pImp)->m_Iterator;
+            break;
+        default:
+            break;
+        }
+
+        m_pImp = pNewImp;
+        return *this;
+    }
+
+    std::pair<const std::string &, const Node &> ConstIterator::operator *()
+    {
+        switch(m_Type)
+        {
+        case SequenceType:
+            return { g_EmptyString, *(static_cast<SequenceConstIteratorImp*>(m_pImp)->m_Iterator->second)};
+            break;
+        case MapType:
+            return {static_cast<MapConstIteratorImp*>(m_pImp)->m_Iterator->first,
+                    *(static_cast<MapConstIteratorImp*>(m_pImp)->m_Iterator->second)};
+            break;
+        default:
+            break;
+        }
+
+        g_NoneNode.Clear();
+        return { g_EmptyString, g_NoneNode};
+    }
+
+    ConstIterator & ConstIterator::operator ++ (int dummy)
+    {
+        switch(m_Type)
+        {
+        case SequenceType:
+            static_cast<SequenceConstIteratorImp*>(m_pImp)->m_Iterator++;
+            break;
+        case MapType:
+            static_cast<MapConstIteratorImp*>(m_pImp)->m_Iterator++;
+            break;
+        default:
+            break;
+        }
+        return *this;
+    }
+
+    ConstIterator & ConstIterator::operator -- (int dummy)
+    {
+        switch(m_Type)
+        {
+        case SequenceType:
+            static_cast<SequenceConstIteratorImp*>(m_pImp)->m_Iterator--;
+            break;
+        case MapType:
+            static_cast<MapConstIteratorImp*>(m_pImp)->m_Iterator--;
+            break;
+        default:
+            break;
+        }
+        return *this;
+    }
+
+    bool ConstIterator::operator == (const ConstIterator & it)
+    {
+        if(m_Type != it.m_Type)
+        {
+            return false;
+        }
+
+        switch(m_Type)
+        {
+        case SequenceType:
+            return static_cast<SequenceConstIteratorImp*>(m_pImp)->m_Iterator == static_cast<SequenceConstIteratorImp*>(it.m_pImp)->m_Iterator;
+            break;
+        case MapType:
+            return static_cast<MapConstIteratorImp*>(m_pImp)->m_Iterator == static_cast<MapConstIteratorImp*>(it.m_pImp)->m_Iterator;
+            break;
+        default:
+            break;
+        }
+
+        return false;
+    }
+
+    bool ConstIterator::operator != (const ConstIterator & it)
+    {
+        return !(*this == it);
+    }
+
+
+    // Node class
+    Node::Node() :
+        m_pImp(new NodeImp)
+    {
+    }
+
+    Node::Node(const Node & node) :
+        Node()
+    {
+        *this = node;
+    }
+
+    Node::Node(const std::string & value) :
+        Node()
+    {
+        *this = value;
+    }
+
+    Node::Node(const char * value) :
+        Node()
+    {
+        *this = value;
+    }
+
+    Node::~Node()
+    {
+        delete static_cast<NodeImp*>(m_pImp);
+    }
+
+    Node::eType Node::Type() const
+    {
+        return NODE_IMP->m_Type;
+    }
+
+    bool Node::IsNone() const
+    {
+        return NODE_IMP->m_Type == Node::None;
+    }
+
+    bool Node::IsSequence() const
+    {
+        return NODE_IMP->m_Type == Node::SequenceType;
+    }
+
+    bool Node::IsMap() const
+    {
+        return NODE_IMP->m_Type == Node::MapType;
+    }
+
+    bool Node::IsScalar() const
+    {
+        return NODE_IMP->m_Type == Node::ScalarType;
+    }
+
+    void Node::Clear()
+    {
+        NODE_IMP->Clear();
+    }
+
+    size_t Node::Size() const
+    {
+        if(TYPE_IMP == nullptr)
+        {
+            return 0;
+        }
+
+        return TYPE_IMP->GetSize();
+    }
+
+    Node & Node::Insert(const size_t index)
+    {
+        NODE_IMP->InitSequence();
+        return *TYPE_IMP->Insert(index);
+    }
+
+    Node & Node::PushFront()
+    {
+        NODE_IMP->InitSequence();
+        return *TYPE_IMP->PushFront();
+    }
+    Node & Node::PushBack()
+    {
+        NODE_IMP->InitSequence();
+        return *TYPE_IMP->PushBack();
+    }
+
+    Node & Node::operator[](const size_t index)
+    {
+        NODE_IMP->InitSequence();
+        Node * pNode = TYPE_IMP->GetNode(index);
+        if(pNode == nullptr)
+        {
+            g_NoneNode.Clear();
+            return g_NoneNode;
+        }
+        return *pNode;
+    }
+
+    Node & Node::operator[](const std::string & key)
+    {
+        NODE_IMP->InitMap();
+        return *TYPE_IMP->GetNode(key);
+    }
+
+    void Node::Erase(const size_t index)
+    {
+        if(TYPE_IMP == nullptr || NODE_IMP->m_Type != Node::SequenceType)
+        {
+            return;
+        }
+
+        return TYPE_IMP->Erase(index);
+    }
+
+    void Node::Erase(const std::string & key)
+    {
+        if(TYPE_IMP == nullptr || NODE_IMP->m_Type != Node::MapType)
+        {
+            return;
+        }
+
+        return TYPE_IMP->Erase(key);
+    }
+
+    Node & Node::operator = (const Node & node)
+    {
+        NODE_IMP->Clear();
+        CopyNode(node, *this);
+        return *this;
+    }
+
+    Node & Node::operator = (const std::string & value)
+    {
+        NODE_IMP->InitScalar();
+        TYPE_IMP->SetData(value);
+        return *this;
+    }
+
+    Node & Node::operator = (const char * value)
+    {
+        NODE_IMP->InitScalar();
+        TYPE_IMP->SetData(value ? std::string(value) : "");
+        return *this;
+    }
+
+    Iterator Node::Begin()
+    {
+        Iterator it;
+
+        if(TYPE_IMP != nullptr)
+        {
+            IteratorImp * pItImp = nullptr;
+
+            switch(NODE_IMP->m_Type)
+            {
+            case Node::SequenceType:
+                it.m_Type = Iterator::SequenceType;
+                pItImp = new SequenceIteratorImp;
+                pItImp->InitBegin(static_cast<SequenceImp*>(TYPE_IMP));
+                break;
+            case Node::MapType:
+                it.m_Type = Iterator::MapType;
+                pItImp = new MapIteratorImp;
+                pItImp->InitBegin(static_cast<MapImp*>(TYPE_IMP));
+                break;
+            default:
+                break;
+            }
+
+            it.m_pImp = pItImp;
+        }
+
+        return it;
+    }
+
+    ConstIterator Node::Begin() const
+    {
+        ConstIterator it;
+
+        if(TYPE_IMP != nullptr)
+        {
+            IteratorImp * pItImp = nullptr;
+
+            switch(NODE_IMP->m_Type)
+            {
+            case Node::SequenceType:
+                it.m_Type = ConstIterator::SequenceType;
+                pItImp = new SequenceConstIteratorImp;
+                pItImp->InitBegin(static_cast<SequenceImp*>(TYPE_IMP));
+                break;
+            case Node::MapType:
+                it.m_Type = ConstIterator::MapType;
+                pItImp = new MapConstIteratorImp;
+                pItImp->InitBegin(static_cast<MapImp*>(TYPE_IMP));
+                break;
+            default:
+                break;
+            }
+
+            it.m_pImp = pItImp;
+        }
+
+        return it;
+    }
+
+    Iterator Node::End()
+    {
+       Iterator it;
+
+        if(TYPE_IMP != nullptr)
+        {
+            IteratorImp * pItImp = nullptr;
+
+            switch(NODE_IMP->m_Type)
+            {
+            case Node::SequenceType:
+                it.m_Type = Iterator::SequenceType;
+                pItImp = new SequenceIteratorImp;
+                pItImp->InitEnd(static_cast<SequenceImp*>(TYPE_IMP));
+                break;
+            case Node::MapType:
+                it.m_Type = Iterator::MapType;
+                pItImp = new MapIteratorImp;
+                pItImp->InitEnd(static_cast<MapImp*>(TYPE_IMP));
+                break;
+            default:
+                break;
+            }
+
+            it.m_pImp = pItImp;
+        }
+
+        return it;
+    }
+
+    ConstIterator Node::End() const
+    {
+       ConstIterator it;
+
+        if(TYPE_IMP != nullptr)
+        {
+            IteratorImp * pItImp = nullptr;
+
+            switch(NODE_IMP->m_Type)
+            {
+            case Node::SequenceType:
+                it.m_Type = ConstIterator::SequenceType;
+                pItImp = new SequenceConstIteratorImp;
+                pItImp->InitEnd(static_cast<SequenceImp*>(TYPE_IMP));
+                break;
+            case Node::MapType:
+                it.m_Type = ConstIterator::MapType;
+                pItImp = new MapConstIteratorImp;
+                pItImp->InitEnd(static_cast<MapImp*>(TYPE_IMP));
+                break;
+            default:
+                break;
+            }
+
+            it.m_pImp = pItImp;
+        }
+
+        return it;
+    }
+
+    const std::string & Node::AsString() const
+    {
+        if(TYPE_IMP == nullptr)
+        {
+            return g_EmptyString;
+        }
+
+        return TYPE_IMP->GetData();
+    }
+
+
+
+    // Reader implementations
+    /**
+    * @breif Line information structure.
+    *
+    */
+    class ReaderLine
+    {
+
+    public:
+
+        /**
+        * @breif Constructor.
+        *
+        */
+        ReaderLine(const std::string & data = "",
+                   const size_t no = 0,
+                   const size_t offset = 0,
+                   const Node::eType type = Node::None,
+                   const unsigned char flags = 0) :
+            Data(data),
+            No(no),
+            Offset(offset),
+            Type(type),
+            Flags(flags),
+            NextLine(nullptr)
+        {
+        }
+
+        enum eFlag
+        {
+            LiteralScalarFlag,      ///< Literal scalar type, defined as "|".
+            FoldedScalarFlag,       ///< Folded scalar type, defined as "<".
+            ScalarNewlineFlag       ///< Scalar ends with a newline.
+        };
+
+        /**
+        * @breif Set flag.
+        *
+        */
+        void SetFlag(const eFlag flag)
+        {
+            Flags |= FlagMask[static_cast<size_t>(flag)];
+        }
+
+        /**
+        * @breif Set flags by mask value.
+        *
+        */
+        void SetFlags(const unsigned char flags)
+        {
+            Flags |= flags;
+        }
+
+        /**
+        * @breif Unset flag.
+        *
+        */
+        void UnsetFlag(const eFlag flag)
+        {
+            Flags &= ~FlagMask[static_cast<size_t>(flag)];
+        }
+
+        /**
+        * @breif Unset flags by mask value.
+        *
+        */
+        void UnsetFlags(const unsigned char flags)
+        {
+            Flags &= ~flags;
+        }
+
+        /**
+        * @breif Get flag value.
+        *
+        */
+        bool GetFlag(const eFlag flag) const
+        {
+            return Flags & FlagMask[static_cast<size_t>(flag)];
+        }
+
+        /**
+        * @breif Copy and replace scalar flags from another ReaderLine.
+        *
+        */
+        void CopyScalarFlags(ReaderLine * from)
+        {
+            if (from == nullptr)
+            {
+                return;
+            }
+
+            unsigned char newFlags = from->Flags & (FlagMask[0] | FlagMask[1] | FlagMask[2]);
+            Flags |= newFlags;
+        }
+
+        static const unsigned char FlagMask[3];
+
+        std::string     Data;       ///< Data of line.
+        size_t          No;         ///< Line number.
+        size_t          Offset;     ///< Offset to first character in data.
+        Node::eType     Type;       ///< Type of line.
+        unsigned char   Flags;      ///< Flags of line.
+        ReaderLine *    NextLine;   ///< Pointer to next line.
+
+
+
+    };
+
+    const unsigned char ReaderLine::FlagMask[3] = { 0x01, 0x02, 0x04 };
+
+
+    /**
+    * @breif Implementation class of Yaml parsing.
+    *        Parsing incoming stream and outputs a root node.
+    *
+    */
+    class ParseImp
+    {
+
+    public:
+
+        /**
+        * @breif Default constructor.
+        *
+        */
+        ParseImp()
+        {
+        }
+
+        /**
+        * @breif Destructor.
+        *
+        */
+        ~ParseImp()
+        {
+            ClearLines();
+        }
+
+        /**
+        * @breif Run full parsing procedure.
+        *
+        */
+        void Parse(Node & root, std::iostream & stream)
+        {
+            try
+            {
+                root.Clear();
+                ReadLines(stream);
+                PostProcessLines();
+                //Print();
+                ParseRoot(root);
+            }
+            catch(Exception e)
+            {
+                root.Clear();
+                throw;
+            }
+        }
+
+    private:
+
+        /**
+        * @breif Copy constructor.
+        *
+        */
+        ParseImp(const ParseImp & copy)
+        {
+
+        }
+
+        /**
+        * @breif Read all lines.
+        *        Ignoring:
+        *           - Empty lines.
+        *           - Comments.
+        *           - Document start/end.
+        *
+        */
+        void ReadLines(std::iostream & stream)
+        {
+            std::string     line = "";
+            size_t          lineNo = 0;
+            bool            documentStartFound = false;
+            bool            foundFirstNotEmpty = false;
+            std::streampos  streamPos = 0;
+
+            // Read all lines, as long as the stream is ok.
+            while (!stream.eof() && !stream.fail())
+            {
+                // Read line
+                streamPos = stream.tellg();
+                std::getline(stream, line);
+                lineNo++;
+
+                // Remove comment
+                const size_t commentPos = FindNotCited(line, '#');
+                if(commentPos != std::string::npos)
+                {
+                    line.resize(commentPos);
+                }
+
+                // Start of document.
+                if (documentStartFound == false && line == "---")
+                {
+                    // Erase all lines before this line.
+                    ClearLines();
+                    documentStartFound = true;
+                    continue;
+                }
+
+                // End of document.
+                if (line == "...")
+                {
+                    break;
+                }
+                else if(line == "---")
+                {
+                    stream.seekg(streamPos);
+                    break;
+                }
+
+                // Remove trailing return.
+                if (line.size())
+                {
+                    if (line[line.size() - 1] == '\r')
+                    {
+                        line.resize(line.size() - 1);
+                    }
+                }
+
+                // Validate characters.
+                for (size_t i = 0; i < line.size(); i++)
+                {
+                    if (static_cast<unsigned char>(line[i]) != '\t' &&
+                       (static_cast<unsigned char>(line[i]) < 32 ||
+                        static_cast<unsigned char>(line[i]) == 127)) 
+                    {
+                        throw ParsingException(ExceptionMessage(g_ErrorInvalidCharacter, lineNo, i + 1));
+                    }
+                }
+                // Validate tabs
+                const size_t firstTabPos    = line.find_first_of('\t');
+                size_t       startOffset    = line.find_first_not_of(" \t");
+
+                // Make sure no tabs are in the very front.
+                if (startOffset != std::string::npos)
+                {
+                    if(firstTabPos < startOffset)
+                    {
+                        throw ParsingException(ExceptionMessage(g_ErrorTabInOffset, lineNo, firstTabPos));
+                    }
+
+                    // Remove front spaces.
+                    line = line.substr(startOffset);
+                }
+                else
+                {
+                    startOffset = 0;
+                    line = "";
+                }
+
+                // Add line.
+                if(foundFirstNotEmpty == false)
+                {
+                    if(line.size())
+                    {
+                        foundFirstNotEmpty = true;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+
+                ReaderLine * pLine = new ReaderLine(line, lineNo, startOffset);
+                m_Lines.push_back(pLine);
+            }
+        }
+
+        /**
+        * @breif Run post-processing on all lines.
+        *        Basically split lines into multiple lines if needed, to follow the parsing algorithm.
+        *
+        */
+        void PostProcessLines()
+        {
+            for (auto it = m_Lines.begin(); it != m_Lines.end();)
+            {
+                // Sequence.
+                if (PostProcessSequenceLine(it) == true)
+                {
+                    continue;
+                }
+
+                // Mapping.
+                if (PostProcessMappingLine(it) == true)
+                {
+                    continue;
+                }
+
+                // Scalar.
+                PostProcessScalarLine(it);
+            }
+
+            // Set next line of all lines.
+            if (m_Lines.size())
+            {
+                if (m_Lines.back()->Type != Node::ScalarType)
+                {
+                    throw ParsingException(ExceptionMessage(g_ErrorUnexpectedDocumentEnd, *m_Lines.back()));
+                }
+
+                if (m_Lines.size() > 1)
+                {
+                    auto prevEnd = m_Lines.end();
+                    --prevEnd;
+
+                    for (auto it = m_Lines.begin(); it != prevEnd; it++)
+                    {
+                        auto nextIt = it;
+                        ++nextIt;
+
+                        (*it)->NextLine = *nextIt;
+                    }
+                }
+            }
+        }
+
+        /**
+        * @breif Run post-processing and check for sequence.
+        *        Split line into two lines if sequence token is not on it's own line.
+        *
+        * @return true if line is sequence, else false.
+        *
+        */
+        bool PostProcessSequenceLine(std::list<ReaderLine *>::iterator & it)
+        {
+            ReaderLine * pLine = *it;
+
+            // Sequence split
+            if (IsSequenceStart(pLine->Data) == false)
+            {
+                return false;
+            }
+
+            pLine->Type = Node::SequenceType;
+
+            ClearTrailingEmptyLines(++it);
+
+            const size_t valueStart = pLine->Data.find_first_not_of(" \t", 1);
+            if (valueStart == std::string::npos)
+            {
+                return true;
+            }
+
+            // Create new line and insert
+            std::string newLine = pLine->Data.substr(valueStart);
+            it = m_Lines.insert(it, new ReaderLine(newLine, pLine->No, pLine->Offset + valueStart));
+            pLine->Data = "";
+
+            return false;
+        }
+
+        /**
+        * @breif Run post-processing and check for mapping.
+        *        Split line into two lines if mapping value is not on it's own line.
+        *
+        * @return true if line is mapping, else move on to scalar parsing.
+        *
+        */
+        bool PostProcessMappingLine(std::list<ReaderLine *>::iterator & it)
+        {
+            ReaderLine * pLine = *it;
+
+            // Find map key.
+            size_t preKeyQuotes = 0;
+            size_t tokenPos = FindNotCited(pLine->Data, ':', preKeyQuotes);
+            if (tokenPos == std::string::npos)
+            {
+                return false;
+            }
+            if(preKeyQuotes > 1)
+            {
+                throw ParsingException(ExceptionMessage(g_ErrorKeyIncorrect, *pLine));
+            }
+
+            pLine->Type = Node::MapType;
+
+            // Get key
+            std::string key = pLine->Data.substr(0, tokenPos);
+            const size_t keyEnd = key.find_last_not_of(" \t");
+            if (keyEnd == std::string::npos)
+            {
+                throw ParsingException(ExceptionMessage(g_ErrorKeyMissing, *pLine));
+            }
+            key.resize(keyEnd + 1);
+
+            // Handle cited key.
+            if(preKeyQuotes == 1)
+            {
+                if(key.front() != '"' || key.back() != '"')
+                {
+                    throw ParsingException(ExceptionMessage(g_ErrorKeyIncorrect, *pLine));
+                }
+
+                key = key.substr(1, key.size() - 2);
+            }
+            RemoveAllEscapeTokens(key);
+
+            // Get value
+            std::string value = "";
+            size_t valueStart = std::string::npos;
+            if (tokenPos + 1 != pLine->Data.size())
+            {
+                valueStart = pLine->Data.find_first_not_of(" \t", tokenPos + 1);
+                if (valueStart != std::string::npos)
+                {
+                    value = pLine->Data.substr(valueStart);
+                }
+            }
+
+            // Make sure the value is not a sequence start.
+            if (IsSequenceStart(value) == true)
+            {
+                throw ParsingException(ExceptionMessage(g_ErrorBlockSequenceNotAllowed, *pLine, valueStart));
+            }
+
+            pLine->Data = key;
+
+
+            // Remove all empty lines after map key.
+            ClearTrailingEmptyLines(++it);
+
+            // Add new empty line?
+            size_t newLineOffset = valueStart;
+            if(newLineOffset == std::string::npos)
+            {
+                if(it != m_Lines.end() && (*it)->Offset > pLine->Offset)
+                {
+                    return true;
+                }
+
+                newLineOffset = tokenPos + 2;
+            }
+            else
+            {
+                newLineOffset += pLine->Offset;
+            }
+
+            // Add new line with value.
+            unsigned char dummyBlockFlags = 0;
+            if(IsBlockScalar(value, pLine->No, dummyBlockFlags) == true)
+            {
+                newLineOffset = pLine->Offset;
+            }
+            ReaderLine * pNewLine = new ReaderLine(value, pLine->No, newLineOffset, Node::ScalarType);
+            it = m_Lines.insert(it, pNewLine);
+
+            // Return false in order to handle next line(scalar value).
+            return false;
+        }
+
+        /**
+        * @breif Run post-processing and check for scalar.
+        *        Checking for multi-line scalars.
+        *
+        * @return true if scalar search should continue, else false.
+        *
+        */
+        void PostProcessScalarLine(std::list<ReaderLine *>::iterator & it)
+        {
+            ReaderLine * pLine = *it;
+            pLine->Type = Node::ScalarType;
+
+            size_t parentOffset = pLine->Offset;
+            if(pLine != m_Lines.front())
+            {
+                 std::list<ReaderLine *>::iterator lastIt = it;
+                --lastIt;
+                parentOffset = (*lastIt)->Offset;
+            }
+
+           std::list<ReaderLine *>::iterator lastNotEmpty = it++;
+
+            // Find last empty lines
+            while(it != m_Lines.end())
+            {
+                pLine = *it;
+                pLine->Type = Node::ScalarType;
+                if(pLine->Data.size())
+                {
+                    if(pLine->Offset <= parentOffset)
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        lastNotEmpty = it;
+                    }
+                }
+                ++it;
+            }
+
+            ClearTrailingEmptyLines(++lastNotEmpty);
+        }
+
+        /**
+        * @breif Process root node and start of document.
+        *
+        */
+        void ParseRoot(Node & root)
+        {
+            // Get first line and start type.
+            auto it = m_Lines.begin();
+            if(it == m_Lines.end())
+            {
+                return;
+            }
+            Node::eType type = (*it)->Type;
+            ReaderLine * pLine = *it;
+
+            // Handle next line.
+            switch(type)
+            {
+            case Node::SequenceType:
+                ParseSequence(root, it);
+                break;
+            case Node::MapType:
+                ParseMap(root, it);
+                break;
+            case Node::ScalarType:
+                ParseScalar(root, it);
+                break;
+            default:
+                break;
+            }
+
+            if(it != m_Lines.end())
+            {
+                throw InternalException(ExceptionMessage(g_ErrorUnexpectedDocumentEnd, *pLine));
+            }
+
+        }
+
+        /**
+        * @breif Process sequence node.
+        *
+        */
+        void ParseSequence(Node & node, std::list<ReaderLine *>::iterator & it)
+        {
+            ReaderLine * pNextLine = nullptr;
+            while(it != m_Lines.end())
+            {
+                ReaderLine * pLine = *it;
+                Node & childNode = node.PushBack();
+
+                // Move to next line, error check.
+                ++it;
+                if(it == m_Lines.end())
+                {
+                    throw InternalException(ExceptionMessage(g_ErrorUnexpectedDocumentEnd, *pLine));
+                }
+
+                // Handle value of map
+                Node::eType valueType = (*it)->Type;
+                switch(valueType)
+                {
+                case Node::SequenceType:
+                    ParseSequence(childNode, it);
+                    break;
+                case Node::MapType:
+                    ParseMap(childNode, it);
+                    break;
+                case Node::ScalarType:
+                    ParseScalar(childNode, it);
+                    break;
+                default:
+                    break;
+                }
+
+                // Check next line. if sequence and correct level, go on, else exit.
+                // If same level but but of type map = error.
+                if(it == m_Lines.end() || ((pNextLine = *it)->Offset < pLine->Offset))
+                {
+                    break;
+                }
+                if(pNextLine->Offset > pLine->Offset)
+                {
+                    throw ParsingException(ExceptionMessage(g_ErrorIncorrectOffset, *pNextLine));
+                }
+                if(pNextLine->Type != Node::SequenceType)
+                {
+                    throw InternalException(ExceptionMessage(g_ErrorDiffEntryNotAllowed, *pNextLine));
+                }
+
+            }
+        }
+
+        /**
+        * @breif Process map node.
+        *
+        */
+        void ParseMap(Node & node, std::list<ReaderLine *>::iterator & it)
+        {
+            ReaderLine * pNextLine = nullptr;
+            while(it != m_Lines.end())
+            {
+                ReaderLine * pLine = *it;
+                Node & childNode = node[pLine->Data];
+
+                // Move to next line, error check.
+                ++it;
+                if(it == m_Lines.end())
+                {
+                    throw InternalException(ExceptionMessage(g_ErrorUnexpectedDocumentEnd, *pLine));
+                }
+
+                // Handle value of map
+                Node::eType valueType = (*it)->Type;
+                switch(valueType)
+                {
+                case Node::SequenceType:
+                    ParseSequence(childNode, it);
+                    break;
+                case Node::MapType:
+                    ParseMap(childNode, it);
+                    break;
+                case Node::ScalarType:
+                    ParseScalar(childNode, it);
+                    break;
+                default:
+                    break;
+                }
+
+                // Check next line. if map and correct level, go on, else exit.
+                // if same level but but of type map = error.
+                if(it == m_Lines.end() || ((pNextLine = *it)->Offset < pLine->Offset))
+                {
+                    break;
+                }
+                if(pNextLine->Offset > pLine->Offset)
+                {
+                    throw ParsingException(ExceptionMessage(g_ErrorIncorrectOffset, *pNextLine));
+                }
+                if(pNextLine->Type != pLine->Type)
+                {
+                    throw InternalException(ExceptionMessage(g_ErrorDiffEntryNotAllowed, *pNextLine));
+                }
+
+            }
+        }
+
+        /**
+        * @breif Process scalar node.
+        *
+        */
+        void ParseScalar(Node & node, std::list<ReaderLine *>::iterator & it)
+        {
+            std::string data = "";
+            ReaderLine * pFirstLine = *it;
+            ReaderLine * pLine = *it;
+
+            // Check if current line is a block scalar.
+            unsigned char blockFlags = 0;
+            bool isBlockScalar = IsBlockScalar(pLine->Data, pLine->No, blockFlags);
+            const bool newLineFlag = static_cast<bool>(blockFlags & ReaderLine::FlagMask[static_cast<size_t>(ReaderLine::ScalarNewlineFlag)]);
+            const bool foldedFlag = static_cast<bool>(blockFlags & ReaderLine::FlagMask[static_cast<size_t>(ReaderLine::FoldedScalarFlag)]);
+            const bool literalFlag = static_cast<bool>(blockFlags & ReaderLine::FlagMask[static_cast<size_t>(ReaderLine::LiteralScalarFlag)]);
+            size_t parentOffset = 0;
+
+            // Find parent offset
+            if(it != m_Lines.begin())
+            {
+                std::list<ReaderLine *>::iterator parentIt = it;
+                --parentIt;
+                parentOffset = (*parentIt)->Offset;
+            }
+
+            // Move to next iterator/line if current line is a block scalar.
+            if(isBlockScalar)
+            {
+                ++it;
+                if(it == m_Lines.end() || (pLine = *it)->Type != Node::ScalarType)
+                {
+                    return;
+                }
+            }
+
+            // Not a block scalar, cut end spaces/tabs
+            if(isBlockScalar == false)
+            {
+                while(1)
+                {
+                    pLine = *it;
+
+                    if(parentOffset != 0 && pLine->Offset <= parentOffset)
+                    {
+                        throw ParsingException(ExceptionMessage(g_ErrorIncorrectOffset, *pLine));
+                    }
+
+                    const size_t endOffset = pLine->Data.find_last_not_of(" \t");
+                    if(endOffset == std::string::npos)
+                    {
+                        data += "\n";
+                    }
+                    else
+                    {
+                        data += pLine->Data.substr(0, endOffset + 1);
+                    }
+
+                    // Move to next line
+                    ++it;
+                    if(it == m_Lines.end() || (*it)->Type != Node::ScalarType)
+                    {
+                        break;
+                    }
+
+                    data += " ";
+                }
+
+                if(ValidateQuote(data) == false)
+                {
+                    throw ParsingException(ExceptionMessage(g_ErrorInvalidQuote, *pFirstLine));
+                }
+            }
+            // Block scalar
+            else
+            {
+                pLine = *it;
+                size_t blockOffset = pLine->Offset;
+                if(blockOffset <= parentOffset)
+                {
+                    throw ParsingException(ExceptionMessage(g_ErrorIncorrectOffset, *pLine));
+                }
+
+                bool addedSpace = false;
+                while(it != m_Lines.end() && (*it)->Type == Node::ScalarType)
+                {
+                    pLine = *it;
+
+                    const size_t endOffset = pLine->Data.find_last_not_of(" \t");
+                    if(endOffset != std::string::npos && pLine->Offset < blockOffset)
+                    {
+                        throw ParsingException(ExceptionMessage(g_ErrorIncorrectOffset, *pLine));
+                    }
+
+                    if(endOffset == std::string::npos)
+                    {
+                        if(addedSpace)
+                        {
+                            data[data.size() - 1] = '\n';
+                            addedSpace = false;
+                        }
+                        else
+                        {
+                            data += "\n";
+                        }
+
+                        ++it;
+                        continue;
+                    }
+                    else
+                    {
+                        if(blockOffset != pLine->Offset && foldedFlag)
+                        {
+                            if(addedSpace)
+                            {
+                                data[data.size() - 1] = '\n';
+                                addedSpace = false;
+                            }
+                            else
+                            {
+                                data += "\n";
+                            }
+                        }
+                        data += std::string(pLine->Offset - blockOffset, ' ');
+                        data += pLine->Data;
+                    }
+
+                    // Move to next line
+                    ++it;
+                    if(it == m_Lines.end() || (*it)->Type != Node::ScalarType)
+                    {
+                        if(newLineFlag)
+                        {
+                            data += "\n";
+                        }
+                        break;
+                    }
+
+                    if(foldedFlag)
+                    {
+                        data += " ";
+                        addedSpace = true;
+                    }
+                    else if(literalFlag && endOffset != std::string::npos)
+                    {
+                        data += "\n";
+                    }
+                }
+            }
+
+            if(data.size() && (data[0] == '"' || data[0] == '\''))
+            {
+                data = data.substr(1, data.size() - 2 );
+            }
+
+            node = data;
+        }
+
+        /**
+        * @breif Debug printing.
+        *
+        */
+        void Print()
+        {
+            for (auto it = m_Lines.begin(); it != m_Lines.end(); it++)
+            {
+
+                ReaderLine * pLine = *it;
+
+                // Print type
+                if (pLine->Type == Node::SequenceType)
+                {
+                    std::cout << "seq ";
+                }
+                else if (pLine->Type == Node::MapType)
+                {
+                    std::cout << "map ";
+                }
+                else if (pLine->Type == Node::ScalarType)
+                {
+                    std::cout << "sca ";
+                }
+                else
+                {
+                    std::cout << "    ";
+                }
+
+                // Print flags
+                if (pLine->GetFlag(ReaderLine::FoldedScalarFlag))
+                {
+                    std::cout << "f";
+                }
+                else
+                {
+                    std::cout << "-";
+                }
+                if (pLine->GetFlag(ReaderLine::LiteralScalarFlag))
+                {
+                    std::cout << "l";
+                }
+                else
+                {
+                    std::cout << "-";
+                }
+                if (pLine->GetFlag(ReaderLine::ScalarNewlineFlag))
+                {
+                    std::cout << "n";
+                }
+                else
+                {
+                    std::cout << "-";
+                }
+                if (pLine->NextLine == nullptr)
+                {
+                    std::cout << "e";
+                }
+                else
+                {
+                    std::cout << "-";
+                }
+
+
+                std::cout << "| ";
+                std::cout << pLine->No << " ";
+                std::cout << std::string(pLine->Offset, ' ');
+
+                if (pLine->Type == Node::ScalarType)
+                {
+                    std::string scalarValue = pLine->Data;
+                    for (size_t i = 0; (i = scalarValue.find("\n", i)) != std::string::npos;)
+                    {
+                        scalarValue.replace(i, 1, "\\n");
+                        i += 2;
+                    }
+                    std::cout << scalarValue << std::endl;
+                }
+                else if (pLine->Type == Node::MapType)
+                {
+                    std::cout << pLine->Data + ":" << std::endl;
+                }
+                else if (pLine->Type == Node::SequenceType)
+                {
+                    std::cout << "-" << std::endl;
+                }
+                else
+                {
+                    std::cout << "> UNKOWN TYPE <" << std::endl;
+                }
+            }
+        }
+
+        /**
+        * @breif Clear all read lines.
+        *
+        */
+        void ClearLines()
+        {
+            for (auto it = m_Lines.begin(); it != m_Lines.end(); it++)
+            {
+                delete *it;
+            }
+            m_Lines.clear();
+        }
+
+        void ClearTrailingEmptyLines(std::list<ReaderLine *>::iterator & it)
+        {
+            while(it != m_Lines.end())
+            {
+                ReaderLine * pLine = *it;
+                if(pLine->Data.size() == 0)
+                {
+                    delete *it;
+                    it = m_Lines.erase(it);
+                }
+                else
+                {
+                    return;
+                }
+
+            }
+        }
+
+        static bool IsSequenceStart(const std::string & data)
+        {
+            if (data.size() == 0 || data[0] != '-')
+            {
+                return false;
+            }
+
+            if (data.size() >= 2 && data[1] != ' ')
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        static bool IsBlockScalar(const std::string & data, const size_t line, unsigned char & flags)
+        {
+            flags = 0;
+            if(data.size() == 0)
+            {
+                return false;
+            }
+
+            if(data[0] == '|')
+            {
+                if(data.size() >= 2)
+                {
+                    if(data[1] != '-' && data[1] != ' ' && data[1] != '\t')
+                    {
+                        throw ParsingException(ExceptionMessage(g_ErrorInvalidBlockScalar, line, data));
+                    }
+                }
+                else
+                {
+                    flags |= ReaderLine::FlagMask[static_cast<size_t>(ReaderLine::ScalarNewlineFlag)];
+                }
+                flags |= ReaderLine::FlagMask[static_cast<size_t>(ReaderLine::LiteralScalarFlag)];
+                return true;
+            }
+
+            if(data[0] == '>')
+            {
+                if(data.size() >= 2)
+                {
+                    if(data[1] != '-' && data[1] != ' ' && data[1] != '\t')
+                    {
+                        throw ParsingException(ExceptionMessage(g_ErrorInvalidBlockScalar, line, data));
+                    }
+                }
+                else
+                {
+                    flags |= ReaderLine::FlagMask[static_cast<size_t>(ReaderLine::ScalarNewlineFlag)];
+                }
+                flags |= ReaderLine::FlagMask[static_cast<size_t>(ReaderLine::FoldedScalarFlag)];
+                return true;
+            }
+
+            return false;
+        }
+
+        std::list<ReaderLine *> m_Lines;    ///< List of lines.
+
+    };
+
+    // Parsing functions
+    void Parse(Node & root, const char * filename)
+    {
+        std::ifstream f(filename, std::ifstream::binary);
+        if (f.is_open() == false)
+        {
+            throw OperationException(g_ErrorCannotOpenFile);
+        }
+
+        f.seekg(0, f.end);
+        size_t fileSize = static_cast<size_t>(f.tellg());
+        f.seekg(0, f.beg);
+
+        std::unique_ptr<char[]> data(new char[fileSize]);
+        f.read(data.get(), fileSize);
+        f.close();
+
+        Parse(root, data.get(), fileSize);
+    }
+
+    void Parse(Node & root, std::iostream & stream)
+    {
+        ParseImp * pImp = nullptr;
+
+        try
+        {
+            pImp = new ParseImp;
+            pImp->Parse(root, stream);
+            delete pImp;
+        }
+        catch (const Exception e)
+        {
+            delete pImp;
+            throw;
+        }
+    }
+
+    void Parse(Node & root, const std::string & string)
+    {
+        std::stringstream ss(string);
+        Parse(root, ss);
+    }
+
+    void Parse(Node & root, const char * buffer, const size_t size)
+    {
+        std::stringstream ss(std::string(buffer, size));
+        Parse(root, ss);
+    }
+
+
+    // Serialize configuration structure.
+    SerializeConfig::SerializeConfig(const size_t spaceIndentation,
+                                     const size_t scalarMaxLength,
+                                     const bool sequenceMapNewline,
+                                     const bool mapScalarNewline) :
+        SpaceIndentation(spaceIndentation),
+        ScalarMaxLength(scalarMaxLength),
+        SequenceMapNewline(sequenceMapNewline),
+        MapScalarNewline(mapScalarNewline)
+    {
+    }
+
+
+    // Serialization functions
+    void Serialize(const Node & root, const char * filename, const SerializeConfig & config)
+    {
+        std::stringstream stream;
+        Serialize(root, stream, config);
+
+        std::ofstream f(filename);
+        if (f.is_open() == false)
+        {
+            throw OperationException(g_ErrorCannotOpenFile);
+        }
+
+        f.write(stream.str().c_str(), stream.str().size());
+        f.close();
+    }
+
+    size_t LineFolding(const std::string & input, std::vector<std::string> & folded, const size_t maxLength)
+    {
+        folded.clear();
+        if(input.size() == 0)
+        {
+            return 0;
+        }
+
+        size_t currentPos = 0;
+        size_t lastPos = 0;
+        size_t spacePos = std::string::npos;
+        while(currentPos < input.size())
+        {
+            currentPos = lastPos + maxLength;
+
+            if(currentPos < input.size())
+            {
+               spacePos = input.find_first_of(' ', currentPos);
+            }
+
+            if(spacePos == std::string::npos || currentPos >= input.size())
+            {
+                const std::string endLine = input.substr(lastPos);
+                if(endLine.size())
+                {
+                    folded.push_back(endLine);
+                }
+
+                return folded.size();
+            }
+
+            folded.push_back(input.substr(lastPos, spacePos - lastPos));
+
+            lastPos = spacePos + 1;
+        }
+
+        return folded.size();
+    }
+
+    static void SerializeLoop(const Node & node, std::iostream & stream, bool useLevel, const size_t level, const SerializeConfig & config)
+    {
+        const size_t indention = config.SpaceIndentation;
+
+        switch(node.Type())
+        {
+            case Node::SequenceType:
+            {
+                for(auto it = node.Begin(); it != node.End(); it++)
+                {
+                    const Node & value = (*it).second;
+                    if(value.IsNone())
+                    {
+                        continue;
+                    }
+                    stream << std::string(level, ' ') << "- ";
+                    useLevel = false;
+                    if(value.IsSequence() || (value.IsMap() && config.SequenceMapNewline == true))
+                    {
+                        useLevel = true;
+                        stream << "\n";
+                    }
+
+                    SerializeLoop(value, stream, useLevel, level + 2, config);
+                }
+
+            }
+            break;
+            case Node::MapType:
+            {
+                size_t count = 0;
+                for(auto it = node.Begin(); it != node.End(); it++)
+                {
+                    const Node & value = (*it).second;
+                    if(value.IsNone())
+                    {
+                        continue;
+                    }
+
+                    if(useLevel || count > 0)
+                    {
+                       stream << std::string(level, ' ');
+                    }
+
+                    std::string key = (*it).first;
+                    AddEscapeTokens(key, "\\\"");
+                    if(ShouldBeCited(key))
+                    {
+                        stream << "\"" << key << "\"" << ": ";
+                    }
+                    else
+                    {
+                        stream << key << ": ";
+                    }
+
+
+                    useLevel = false;
+                    if(value.IsScalar() == false || (value.IsScalar() && config.MapScalarNewline))
+                    {
+                        useLevel = true;
+                        stream << "\n";
+                    }
+
+                    SerializeLoop(value, stream, useLevel, level + indention, config);
+
+                    useLevel = true;
+                    count++;
+                }
+
+            }
+            break;
+            case Node::ScalarType:
+            {
+                const std::string value = node.As<std::string>();
+
+                // Empty scalar
+                if(value.size() == 0)
+                {
+                    stream << "\n";
+                    break;
+                }
+
+                // Get lines of scalar.
+                std::string line = "";
+                std::vector<std::string> lines;
+                std::istringstream iss(value);
+                while (iss.eof() == false)
+                {
+                    std::getline(iss, line);
+                    lines.push_back(line);
+                }
+
+                // Block scalar
+                const std::string & lastLine = lines.back();
+                const bool endNewline = lastLine.size() == 0;
+                if(endNewline)
+                {
+                    lines.pop_back();
+                }
+
+                // Literal
+                if(lines.size() > 1)
+                {
+                    stream << "|";
+                }
+                // Folded/plain
+                else
+                {
+                    const std::string frontLine = lines.front();
+                    if(config.ScalarMaxLength == 0 || lines.front().size() <= config.ScalarMaxLength ||
+                       LineFolding(frontLine, lines, config.ScalarMaxLength) == 1)
+                    {
+                        if(useLevel)
+                        {
+                             stream << std::string(level, ' ');
+                        }
+
+                        if(ShouldBeCited(value))
+                        {
+                            stream << "\"" << value << "\"\n";
+                            break;
+                        }
+                        stream << value << "\n";
+                        break;
+                    }
+                    else
+                    {
+                        stream << ">";
+                    }
+                }
+
+                if(endNewline == false)
+                {
+                     stream << "-";
+                }
+                stream << "\n";
+
+
+                for(auto it = lines.begin(); it != lines.end(); it++)
+                {
+                    stream << std::string(level, ' ') << (*it) << "\n";
+                }
+            }
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    void Serialize(const Node & root, std::iostream & stream, const SerializeConfig & config)
+    {
+        if(config.SpaceIndentation < 2)
+        {
+            throw OperationException(g_ErrorIndentation);
+        }
+
+        SerializeLoop(root, stream, false, 0, config);
+    }
+
+    void Serialize(const Node & root, std::string & string, const SerializeConfig & config)
+    {
+        std::stringstream stream;
+        Serialize(root, stream, config);
+        string = stream.str();
+    }
+
+
+
+    // Static function implementations
+    std::string ExceptionMessage(const std::string & message, ReaderLine & line)
+    {
+        return message + std::string(" Line ") + std::to_string(line.No) + std::string(": ") + line.Data;
+    }
+
+    std::string ExceptionMessage(const std::string & message, ReaderLine & line, const size_t errorPos)
+    {
+        return message + std::string(" Line ") + std::to_string(line.No) + std::string(" column ") + std::to_string(errorPos + 1) + std::string(": ") + line.Data;
+    }
+
+    std::string ExceptionMessage(const std::string & message, const size_t errorLine, const size_t errorPos)
+    {
+        return message + std::string(" Line ") + std::to_string(errorLine) + std::string(" column ") + std::to_string(errorPos);
+    }
+
+    std::string ExceptionMessage(const std::string & message, const size_t errorLine, const std::string & data)
+    {
+        return message + std::string(" Line ") + std::to_string(errorLine) + std::string(": ") + data;
+    }
+
+    bool FindQuote(const std::string & input, size_t & start, size_t & end, size_t searchPos)
+    {
+        start = end = std::string::npos;
+        size_t qPos = searchPos;
+        bool foundStart = false;
+
+        while(qPos != std::string::npos)
+        {
+            // Find first quote.
+            qPos = input.find_first_of("\"'", qPos);
+            if(qPos == std::string::npos)
+            {
+                return false;
+            }
+
+            const char token = input[qPos];
+            if(token == '"' && (qPos == 0 || input[qPos-1] != '\\'))
+            {
+                // Found start quote.
+                if(foundStart == false)
+                {
+                    start = qPos;
+                    foundStart = true;
+                }
+                // Found end quote
+                else
+                {
+                    end = qPos;
+                    return true;
+                }
+            }
+
+            // Check if it's possible for another loop.
+            if(qPos + 1 == input.size())
+            {
+                return false;
+            }
+            qPos++;
+        }
+
+        return false;
+    }
+
+    size_t FindNotCited(const std::string & input, char token, size_t & preQuoteCount)
+    {
+        preQuoteCount = 0;
+        size_t tokenPos = input.find_first_of(token);
+        if(tokenPos == std::string::npos)
+        {
+            return std::string::npos;
+        }
+
+        // Find all quotes
+        std::vector<std::pair<size_t, size_t>> quotes;
+
+        size_t quoteStart = 0;
+        size_t quoteEnd = 0;
+        while(FindQuote(input, quoteStart, quoteEnd, quoteEnd))
+        {
+            quotes.push_back({quoteStart, quoteEnd});
+
+            if(quoteEnd + 1 == input.size())
+            {
+                break;
+            }
+            quoteEnd++;
+        }
+
+        if(quotes.size() == 0)
+        {
+            return tokenPos;
+        }
+
+        size_t currentQuoteIndex = 0;
+        std::pair<size_t, size_t> currentQuote = {0, 0};
+
+        while(currentQuoteIndex < quotes.size())
+        {
+            currentQuote = quotes[currentQuoteIndex];
+
+            if(tokenPos < currentQuote.first)
+            {
+                return tokenPos;
+            }
+            preQuoteCount++;
+            if(tokenPos <= currentQuote.second)
+            {
+                // Find next token
+                if(tokenPos + 1 == input.size())
+                {
+                    return std::string::npos;
+                }
+                tokenPos = input.find_first_of(token, tokenPos + 1);
+                if(tokenPos == std::string::npos)
+                {
+                    return std::string::npos;
+                }
+            }
+
+            currentQuoteIndex++;
+        }
+
+        return tokenPos;
+    }
+
+    size_t FindNotCited(const std::string & input, char token)
+    {
+        size_t dummy = 0;
+        return FindNotCited(input, token, dummy);
+    }
+
+    bool ValidateQuote(const std::string & input)
+    {
+        if(input.size() == 0)
+        {
+            return true;
+        }
+
+        char token = 0;
+        size_t searchPos = 0;
+        if(input[0] == '\"' || input[0] == '\'')
+        {
+            if(input.size() == 1)
+            {
+                return false;
+            }
+            token = input[0];
+            searchPos = 1;
+        }
+
+        while(searchPos != std::string::npos && searchPos < input.size() - 1)
+        {
+            searchPos = input.find_first_of("\"'", searchPos + 1);
+            if(searchPos == std::string::npos)
+            {
+                break;
+            }
+
+            const char foundToken = input[searchPos];
+
+            if(input[searchPos] == '\"' || input[searchPos] == '\'')
+            {
+                if(token == 0 && input[searchPos-1] != '\\')
+                {
+                    return false;
+                }
+                //if(foundToken == token)
+                //{
+
+                    /*if(foundToken == token && searchPos == input.size() - 1 && input[searchPos-1] != '\\')
+                    {
+                        return true;
+                        if(searchPos == input.size() - 1)
+                        {
+                            return true;
+                        }
+                        return false;
+                    }
+                    else */
+                    if(foundToken == token && input[searchPos-1] != '\\')
+                    {
+                        if(searchPos == input.size() - 1)
+                        {
+                            return true;
+                        }
+                        return false;
+                    }
+                //}
+            }
+        }
+
+        return token == 0;
+    }
+
+    void CopyNode(const Node & from, Node & to)
+    {
+        const Node::eType type = from.Type();
+
+        switch(type)
+        {
+        case Node::SequenceType:
+            for(auto it = from.Begin(); it != from.End(); it++)
+            {
+                const Node & currentNode = (*it).second;
+                Node & newNode = to.PushBack();
+                CopyNode(currentNode, newNode);
+            }
+            break;
+        case Node::MapType:
+            for(auto it = from.Begin(); it != from.End(); it++)
+            {
+                const Node & currentNode = (*it).second;
+                Node & newNode = to[(*it).first];
+                CopyNode(currentNode, newNode);
+            }
+            break;
+        case Node::ScalarType:
+            to = from.As<std::string>();
+            break;
+        case Node::None:
+            break;
+        }
+    }
+
+    bool ShouldBeCited(const std::string & key)
+    {
+        return key.find_first_of("\":{}[],&*#?|-<>=!%@") != std::string::npos;
+    }
+
+    void AddEscapeTokens(std::string & input, const std::string & tokens)
+    {
+        for(auto it = tokens.begin(); it != tokens.end(); it++)
+        {
+            const char token = *it;
+            const std::string replace = std::string("\\") + std::string(1, token);
+            size_t found = input.find_first_of(token);
+            while(found != std::string::npos)
+            {
+                input.replace(found, 1, replace);
+                found = input.find_first_of(token, found + 2);
+            }
+        }
+    }
+
+    void RemoveAllEscapeTokens(std::string & input)
+    {
+        size_t found = input.find_first_of("\\");
+        while(found != std::string::npos)
+        {
+            if(found + 1 == input.size())
+            {
+                return;
+            }
+
+            std::string replace(1, input[found + 1]);
+            input.replace(found, 2, replace);
+            found = input.find_first_of("\\", found + 1);
+        }
+    }
+
+
+}

--- a/lib/3rdparty/miniyaml/yaml/yaml.hpp
+++ b/lib/3rdparty/miniyaml/yaml/yaml.hpp
@@ -1,0 +1,656 @@
+/*
+* MIT License
+*
+* Copyright(c) 2018 Jimmie Bergmann
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files(the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions :
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+*/
+
+/*
+YAML documentation:
+http://yaml.org/spec/1.0/index.html
+https://www.codeproject.com/Articles/28720/YAML-Parser-in-C
+*/
+
+#pragma once
+
+#include <exception>
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <algorithm>
+#include <map>
+
+/**
+* @breif Namespace wrapping mini-yaml classes.
+*
+*/
+namespace Yaml
+{
+
+    /**
+    * @breif Forward declarations.
+    *
+    */
+    class Node;
+
+
+    /**
+    * @breif Helper classes and functions
+    *
+    */
+    namespace impl
+    {
+
+        /**
+        * @breif Helper functionality, converting string to any data type.
+        *        Strings are left untouched.
+        *
+        */
+        template<typename T>
+        struct StringConverter
+        {
+            static T Get(const std::string & data)
+            {
+                T type;
+                std::stringstream ss(data);
+                ss >> type;
+                return type;
+            }
+
+            static T Get(const std::string & data, const T & defaultValue)
+            {
+                T type;
+                std::stringstream ss(data);
+                ss >> type;
+
+                if(ss.fail())
+                {
+                    return defaultValue;
+                }
+
+                return type;
+            }
+        };
+        template<>
+        struct StringConverter<std::string>
+        {
+            static std::string Get(const std::string & data)
+            {
+                return data;
+            }
+
+            static std::string Get(const std::string & data, const std::string & defaultValue)
+            {
+                if(data.size() == 0)
+                {
+                    return defaultValue;
+                }
+                return data;
+            }
+        };
+
+        template<>
+        struct StringConverter<bool>
+        {
+            static bool Get(const std::string & data)
+            {
+                std::string tmpData = data;
+                std::transform(tmpData.begin(), tmpData.end(), tmpData.begin(), ::tolower);
+                if(tmpData == "true" || tmpData == "yes" || tmpData == "1")
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            static bool Get(const std::string & data, const bool & defaultValue)
+            {
+                if(data.size() == 0)
+                {
+                    return defaultValue;
+                }
+
+                return Get(data);
+            }
+        };
+
+    }
+
+
+    /**
+    * @breif Exception class.
+    *
+    */
+    class Exception : public std::runtime_error
+    {
+
+    public:
+
+        /**
+        * @breif Enumeration of exception types.
+        *
+        */
+        enum eType
+        {
+            InternalError,  ///< Internal error.
+            ParsingError,   ///< Invalid parsing data.
+            OperationError  ///< User operation error.
+        };
+
+        /**
+        * @breif Constructor.
+        *
+        * @param message    Exception message.
+        * @param type       Type of exception.
+        *
+        */
+        Exception(const std::string & message, const eType type);
+
+        /**
+        * @breif Get type of exception.
+        *
+        */
+        eType Type() const;
+
+        /**
+        * @breif Get message of exception.
+        *
+        */
+        const char * Message() const;
+
+    private:
+
+        eType m_Type;   ///< Type of exception.
+
+    };
+
+
+    /**
+    * @breif Internal exception class.
+    *
+    * @see Exception
+    *
+    */
+    class InternalException : public Exception
+    {
+
+    public:
+
+        /**
+        * @breif Constructor.
+        *
+        * @param message Exception message.
+        *
+        */
+        InternalException(const std::string & message);
+
+    };
+
+
+    /**
+    * @breif Parsing exception class.
+    *
+    * @see Exception
+    *
+    */
+    class ParsingException : public Exception
+    {
+
+    public:
+
+        /**
+        * @breif Constructor.
+        *
+        * @param message Exception message.
+        *
+        */
+        ParsingException(const std::string & message);
+
+    };
+
+
+    /**
+    * @breif Operation exception class.
+    *
+    * @see Exception
+    *
+    */
+    class OperationException : public Exception
+    {
+
+    public:
+
+        /**
+        * @breif Constructor.
+        *
+        * @param message Exception message.
+        *
+        */
+        OperationException(const std::string & message);
+
+    };
+
+
+    /**
+    * @breif Iterator class.
+    *
+    */
+    class Iterator
+    {
+
+    public:
+
+        friend class Node;
+
+        /**
+        * @breif Default constructor.
+        *
+        */
+        Iterator();
+
+        /**
+        * @breif Copy constructor.
+        *
+        */
+        Iterator(const Iterator & it);
+
+        /**
+        * @breif Assignment operator.
+        *
+        */
+        Iterator & operator = (const Iterator & it);
+
+        /**
+        * @breif Destructor.
+        *
+        */
+        ~Iterator();
+
+        /**
+        * @breif Get node of iterator.
+        *        First pair item is the key of map value, empty if type is sequence.
+        *
+        */
+        std::pair<const std::string &, Node &> operator *();
+
+        /**
+        * @breif Post-increment operator.
+        *
+        */
+        Iterator & operator ++ (int);
+
+        /**
+        * @breif Post-decrement operator.
+        *
+        */
+        Iterator & operator -- (int);
+
+        /**
+        * @breif Check if iterator is equal to other iterator.
+        *
+        */
+        bool operator == (const Iterator & it);
+
+        /**
+        * @breif Check if iterator is not equal to other iterator.
+        *
+        */
+        bool operator != (const Iterator & it);
+
+    private:
+
+        enum eType
+        {
+            None,
+            SequenceType,
+            MapType
+        };
+
+        eType   m_Type; ///< Type of iterator.
+        void *  m_pImp; ///< Implementation of iterator class.
+
+    };
+
+
+    /**
+    * @breif Constant iterator class.
+    *
+    */
+    class ConstIterator
+    {
+
+    public:
+
+        friend class Node;
+
+        /**
+        * @breif Default constructor.
+        *
+        */
+        ConstIterator();
+
+        /**
+        * @breif Copy constructor.
+        *
+        */
+        ConstIterator(const ConstIterator & it);
+
+        /**
+        * @breif Assignment operator.
+        *
+        */
+        ConstIterator & operator = (const ConstIterator & it);
+
+        /**
+        * @breif Destructor.
+        *
+        */
+        ~ConstIterator();
+
+        /**
+        * @breif Get node of iterator.
+        *        First pair item is the key of map value, empty if type is sequence.
+        *
+        */
+        std::pair<const std::string &, const Node &> operator *();
+
+        /**
+        * @breif Post-increment operator.
+        *
+        */
+        ConstIterator & operator ++ (int);
+
+        /**
+        * @breif Post-decrement operator.
+        *
+        */
+        ConstIterator & operator -- (int);
+
+        /**
+        * @breif Check if iterator is equal to other iterator.
+        *
+        */
+        bool operator == (const ConstIterator & it);
+
+        /**
+        * @breif Check if iterator is not equal to other iterator.
+        *
+        */
+        bool operator != (const ConstIterator & it);
+
+    private:
+
+        enum eType
+        {
+            None,
+            SequenceType,
+            MapType
+        };
+
+        eType   m_Type; ///< Type of iterator.
+        void *  m_pImp; ///< Implementation of constant iterator class.
+
+    };
+
+
+    /**
+    * @breif Node class.
+    *
+    */
+    class Node
+    {
+
+    public:
+
+        friend class Iterator;
+
+        /**
+        * @breif Enumeration of node types.
+        *
+        */
+        enum eType
+        {
+            None,
+            SequenceType,
+            MapType,
+            ScalarType
+        };
+
+        /**
+        * @breif Default constructor.
+        *
+        */
+        Node();
+
+        /**
+        * @breif Copy constructor.
+        *
+        */
+        Node(const Node & node);
+
+        /**
+        * @breif Assignment constructors.
+        *        Converts node to scalar type if needed.
+        *
+        */
+        Node(const std::string & value);
+        Node(const char * value);
+
+        /**
+        * @breif Destructor.
+        *
+        */
+        ~Node();
+
+        /**
+        * @breif Functions for checking type of node.
+        *
+        */
+        eType Type() const;
+        bool IsNone() const;
+        bool IsSequence() const;
+        bool IsMap() const;
+        bool IsScalar() const;
+
+        /**
+        * @breif Completely clear node.
+        *
+        */
+        void Clear();
+
+        /**
+        * @breif Get node as given template type.
+        *
+        */
+        template<typename T>
+        T As() const
+        {
+            return impl::StringConverter<T>::Get(AsString());
+        }
+
+        /**
+        * @breif Get node as given template type.
+        *
+        */
+        template<typename T>
+        T As(const T & defaultValue) const
+        {
+            return impl::StringConverter<T>::Get(AsString(), defaultValue);
+        }
+
+        /**
+        * @breif Get size of node.
+        *        Nodes of type None or Scalar will return 0.
+        *
+        */
+        size_t Size() const;
+
+        // Sequence operators
+
+        /**
+        * @breif Insert sequence item at given index.
+        *        Converts node to sequence type if needed.
+        *        Adding new item to end of sequence if index is larger than sequence size.
+        *
+        */
+        Node & Insert(const size_t index);
+
+        /**
+        * @breif Add new sequence index to back.
+        *        Converts node to sequence type if needed.
+        *
+        */
+        Node & PushFront();
+
+         /**
+        * @breif Add new sequence index to front.
+        *        Converts node to sequence type if needed.
+        *
+        */
+        Node & PushBack();
+
+        /**
+        * @breif    Get sequence/map item.
+        *           Converts node to sequence/map type if needed.
+        *
+        * @param index  Sequence index. Returns None type Node if index is unknown.
+        * @param key    Map key. Creates a new node if key is unknown.
+        *
+        */
+        Node & operator []  (const size_t index);
+        Node & operator [] (const std::string & key);
+
+        /**
+        * @breif Erase item.
+        *        No action if node is not a sequence or map.
+        *
+        */
+        void Erase(const size_t index);
+        void Erase(const std::string & key);
+
+        /**
+        * @breif Assignment operators.
+        *
+        */
+        Node & operator = (const Node & node);
+        Node & operator = (const std::string & value);
+        Node & operator = (const char * value);
+
+        /**
+        * @breif Get start iterator.
+        *
+        */
+        Iterator Begin();
+        ConstIterator Begin() const;
+
+        /**
+        * @breif Get end iterator.
+        *
+        */
+        Iterator End();
+        ConstIterator End() const;
+
+
+    private:
+
+        /**
+        * @breif Get as string. If type is scalar, else empty.
+        *
+        */
+        const std::string & AsString() const;
+
+        void * m_pImp; ///< Implementation of node class.
+
+    };
+
+
+    /**
+    * @breif Parsing functions.
+    *        Population given root node with deserialized data.
+    *
+    * @param root       Root node to populate.
+    * @param filename   Path of input file.
+    * @param stream     Input stream.
+    * @param string     String of input data.
+    * @param buffer     Char array of input data.
+    * @param size       Buffer size.
+    *
+    * @throw InternalException  An internal error occurred.
+    * @throw ParsingException   Invalid input YAML data.
+    * @throw OperationException If filename or buffer pointer is invalid.
+    *
+    */
+    void Parse(Node & root, const char * filename);
+    void Parse(Node & root, std::iostream & stream);
+    void Parse(Node & root, const std::string & string);
+    void Parse(Node & root, const char * buffer, const size_t size);
+
+
+    /**
+    * @breif    Serialization configuration structure,
+    *           describing output behavior.
+    *
+    */
+    struct SerializeConfig
+    {
+
+        /**
+        * @breif Constructor.
+        *
+        * @param spaceIndentation       Number of spaces per indentation.
+        * @param scalarMaxLength        Maximum length of scalars. Serialized as folder scalars if exceeded.
+        *                               Ignored if equal to 0.
+        * @param sequenceMapNewline     Put maps on a new line if parent node is a sequence.
+        * @param mapScalarNewline       Put scalars on a new line if parent node is a map.
+        *
+        */
+        SerializeConfig(const size_t spaceIndentation = 2,
+                        const size_t scalarMaxLength = 64,
+                        const bool sequenceMapNewline = false,
+                        const bool mapScalarNewline = false);
+
+        size_t SpaceIndentation;    ///< Number of spaces per indentation.
+        size_t ScalarMaxLength;     ///< Maximum length of scalars. Serialized as folder scalars if exceeded.
+        bool SequenceMapNewline;    ///< Put maps on a new line if parent node is a sequence.
+        bool MapScalarNewline;      ///< Put scalars on a new line if parent node is a map.
+    };
+
+
+    /**
+    * @breif Serialization functions.
+    *
+    * @param root       Root node to serialize.
+    * @param filename   Path of output file.
+    * @param stream     Output stream.
+    * @param string     String of output data.
+    * @param config     Serialization configurations.
+    *
+    * @throw InternalException  An internal error occurred.
+    * @throw OperationException If filename or buffer pointer is invalid.
+    *                           If config is invalid.
+    *
+    */
+    void Serialize(const Node & root, const char * filename, const SerializeConfig & config = {2, 64, false, false});
+    void Serialize(const Node & root, std::iostream & stream, const SerializeConfig & config = {2, 64, false, false});
+    void Serialize(const Node & root, std::string & string, const SerializeConfig & config = {2, 64, false, false});
+
+}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,11 +8,13 @@ set(SOURCES_PRIVATE
 	src/value.cpp
 	src/serialize.cpp
 	3rdparty/tinyxml2/tinyxml2.cpp
+	3rdparty/miniyaml/yaml/yaml.cpp
 )
 
 # List of private header files
 set(HEADERS_PRIVATE
 	3rdparty/tinyxml2/tinyxml2.h
+	3rdparty/miniyaml/yaml/yaml.hpp
 )
 
 # List of public header files

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 # List of private source files
 set(SOURCES_PRIVATE
 	src/archiver_xml.cpp
+	src/archiver_yaml.cpp
 	src/container.cpp
 	src/value.cpp
 	src/serialize.cpp
@@ -21,6 +22,7 @@ set(HEADERS_PRIVATE
 set(HEADERS_PUBLIC
 	include/gpds/archiver.hpp
 	include/gpds/archiver_xml.hpp
+	include/gpds/archiver_yaml.hpp
 	include/gpds/attributes.hpp
 	include/gpds/container.hpp
 	include/gpds/serialize.hpp

--- a/lib/include/gpds/archiver_yaml.hpp
+++ b/lib/include/gpds/archiver_yaml.hpp
@@ -48,6 +48,7 @@ namespace gpds
         void write_entry(Yaml::Node& root, const container& container) const;
         void read_entry(const Yaml::Node& root, container& container);
         bool key_exist(const Yaml::Node& root, const std::string& key) const;
+        void read_value(const Yaml::Node& node, value& value) const;
     };
 
 }

--- a/lib/include/gpds/archiver_yaml.hpp
+++ b/lib/include/gpds/archiver_yaml.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "archiver.hpp"
+
+#include <istream>
+#include <ostream>
+
+namespace Yaml
+{
+    class Node;
+}
+
+namespace gpds
+{
+    /**
+     * An archiver to (de)serialize to/from YAML.
+     */
+    class archiver_yaml :
+        public archiver
+    {
+    public:
+        // Deal with name hiding
+        using archiver::save;
+        using archiver::load;
+
+        const std::string NAMESPACE_PREFIX = "gpds:";
+
+        struct settings
+        {
+            bool annotate_list_count = false;
+            bool prefix_annotations  = true;
+        };
+
+        struct settings settings;
+
+        archiver_yaml() = default;
+        archiver_yaml(const archiver_yaml& other) = delete;
+        archiver_yaml(archiver_yaml&& other) noexcept = delete;
+        ~archiver_yaml() override = default;
+
+        archiver_yaml& operator=(const archiver_yaml& rhs) = delete;
+        archiver_yaml& operator=(archiver_yaml&& rhs) noexcept = delete;
+
+        bool save(std::ostream& stream, const container& container, std::string_view root_name) const override;
+        bool load(std::istream& stream, container& container, std::string_view root_name) override;
+
+    private:
+        void write_entry(Yaml::Node& root, const container& container) const;
+        void read_entry(const Yaml::Node& root, container& container);
+    };
+
+}

--- a/lib/include/gpds/archiver_yaml.hpp
+++ b/lib/include/gpds/archiver_yaml.hpp
@@ -47,6 +47,7 @@ namespace gpds
     private:
         void write_entry(Yaml::Node& root, const container& container) const;
         void read_entry(const Yaml::Node& root, container& container);
+        bool key_exist(const Yaml::Node& root, const std::string& key) const;
     };
 
 }

--- a/lib/include/gpds/serialize.hpp
+++ b/lib/include/gpds/serialize.hpp
@@ -13,6 +13,14 @@ namespace gpds
     class serialize
     {
     public:
+        /**
+         * The mode of the serialize.
+         */
+        enum mode {
+            XML  = 0,
+            YAML = 1,
+        };
+
         virtual ~serialize() = default;
 
         // Container
@@ -20,12 +28,12 @@ namespace gpds
         virtual void from_container(const gpds::container& container) = 0;
 
         // String
-        std::pair<bool, std::string> to_string(std::string& str, std::string_view root_name) const;
-        std::pair<bool, std::string> from_string(std::string_view str, std::string_view root_name);
+        std::pair<bool, std::string> to_string(std::string& str, std::string_view root_name, enum mode mode = mode::XML) const;
+        std::pair<bool, std::string> from_string(std::string_view str, std::string_view root_name, enum mode mode = mode::XML);
 
         // File
-        std::pair<bool, std::string> to_file(const std::filesystem::path& path, std::string_view root_name) const;
-        std::pair<bool, std::string> from_file(const std::filesystem::path& path, std::string_view root_name);
+        std::pair<bool, std::string> to_file(const std::filesystem::path& path, std::string_view root_name, enum mode mode = mode::XML) const;
+        std::pair<bool, std::string> from_file(const std::filesystem::path& path, std::string_view root_name, enum mode mode = mode::XML);
     };
 
 }

--- a/lib/src/archiver_yaml.cpp
+++ b/lib/src/archiver_yaml.cpp
@@ -1,0 +1,239 @@
+#include "archiver_yaml.hpp"
+#include "utils.hpp"
+#include "../3rdparty/miniyaml/yaml/yaml.hpp"
+
+#include <algorithm>
+
+using namespace gpds;
+
+bool
+archiver_yaml::save(std::ostream& stream, const container& container, std::string_view root_name) const
+{
+    // Create the YAML document node
+    Yaml::Node root;
+    Yaml::Node node;
+    // Handle all nodes children recursively
+    write_entry(node, container);
+    // Add child node to root
+    root[root_name.data()] = node;
+    // Serialize the document
+    std::string data = "";
+    Yaml::Serialize(root, data);
+    // Write the document to the stream
+    stream << data;
+
+    return true;
+}
+
+bool
+archiver_yaml::load(std::istream& stream, container& container, std::string_view root_name)
+{
+    // Create the YAML document node
+    Yaml::Node root;
+    Yaml::Node node;
+    // Read istream into string
+    std::string data((std::istreambuf_iterator<char>(stream)), std::istreambuf_iterator<char>());
+    // Parse the document
+    Yaml::Parse(root, data);
+    // Retrieve the data to container
+    read_entry(root[root_name.data()], container);
+
+    return true;
+}
+
+void
+archiver_yaml::write_entry(Yaml::Node& root, const container& container) const
+{
+    // Annotate list if supposed to
+    if (settings.annotate_list_count && container.is_list()) {
+        std::string attributeString = "count";
+        if (settings.prefix_annotations) {
+            // Generate attribute string
+            attributeString = NAMESPACE_PREFIX + attributeString;
+        }
+        root[attributeString] = std::to_string(container.values.size());
+    }
+
+    // Add all container arguments
+    for (const auto& attribute : container.attributes.map) {
+        // Add "-" prefix for container attributes
+        root["-" + attribute.first] = attribute.second;
+    }
+
+    // Iterate through all values in this container
+    for (const auto& keyValuePair: container.values) {
+
+        // Some aliases to make the code easier to read
+        const auto& key = keyValuePair.first.c_str();
+        const value& value = keyValuePair.second;
+
+        // Create a new node in the DOM
+        Yaml::Node child;
+
+        bool has_attribute = false;
+        // Add all value arguments
+        for (const auto& attribute : value.attributes.map) {
+            // Add "-" prefix for value attributes
+            child["-" + attribute.first] = attribute.second;
+            has_attribute = true;
+        }
+
+        {
+            // Nested container
+            if (value.is_type<gpds::container*>()) {
+                // Recursion
+                const auto child_container = value.get<gpds::container*>().value_or(nullptr);
+                if (child_container) {
+                    // Write child container
+                    write_entry(child, *child_container);
+                }
+            }
+            // Simple value
+            else {
+                // Create text
+                std::string text = value.get<std::string>().value_or("");
+                // Trim whitespace
+                std::string whitespace = " \n\r\t\f\v";
+                size_t start = text.find_first_not_of(whitespace);
+                size_t end = text.find_last_not_of(whitespace);
+                text = (start == std::string::npos) ? "" : text.substr(start);
+                text = (end == std::string::npos) ? "" : text.substr(0, end + 1);
+                // Set null if text is empty
+                if (text.empty()) {
+                    text = "null";
+                }
+                // Set text value by attribute if there are attributes
+                if (has_attribute) {
+                    // Set "#text" attribute if there are attributes
+                    child["#text"] = text;
+                } else {
+                    // Set text to value if there are no attributes
+                    child = text;
+                }
+                // Set "#cdata" attribute if it is cdata
+                if (value.use_cdata()) {
+                    child["#cdata"] = text;
+                }
+            }
+        }
+
+        // Is key existing?
+        bool key_exist = false;
+        switch (root[key].Type())
+        {
+        case Yaml::Node::eType::None:
+            key_exist = false;
+            break;
+        case Yaml::Node::eType::SequenceType:
+        case Yaml::Node::eType::MapType:
+        case Yaml::Node::eType::ScalarType:
+            key_exist = true;
+            break;
+        }
+
+        if (key_exist) {
+            // If repeated key, add to sequence
+            if (root[key].Type() == Yaml::Node::eType::MapType) {
+                Yaml::Node first_node = root[key];
+                root[key].PushBack() = first_node;
+            }
+            root[key].PushBack() = child;
+        } else {
+            // If new key, add to map
+            root[key] = child;
+        }
+    }
+}
+
+void
+archiver_yaml::read_entry(const Yaml::Node& root, container& container)
+{
+    // Iterate through all children
+    for(auto it = root.Begin(); it != root.End(); it++)
+    {
+        const std::string& it_key = (*it).first;
+        const Yaml::Node& it_node = (*it).second;
+        switch (it_node.Type())
+        {
+        case Yaml::Node::eType::None:
+            break;
+        case Yaml::Node::eType::SequenceType:
+            // Handle all SequenceType children recursively
+            for(auto it = it_node.Begin(); it != it_node.End(); it++)
+            {
+                const Yaml::Node& seq_node = (*it).second;
+                gpds::container child_container;
+                read_entry(seq_node, child_container);
+                if (!it_key.empty()) {
+                    container.add_value(it_key, std::move(child_container));
+                }
+            }
+            break;
+        case Yaml::Node::eType::MapType:
+            // Handle all MapType children recursively
+            {
+                gpds::value child_value;
+                bool is_text = false;
+                // Check if this node is a text node
+                for(auto it = it_node.Begin(); it != it_node.End(); it++)
+                {
+                    const std::string& map_key = (*it).first;
+                    const Yaml::Node& map_node = (*it).second;
+                    if (map_node.Type() == Yaml::Node::eType::ScalarType) {
+                        std::string map_text = map_node.As<std::string>();
+                        // Set empty if text is null
+                        if (map_text == "null") {
+                            map_text = "";
+                        }
+                        if (map_key == "#text") {
+                            // This node is a text node
+                            is_text = true;
+                            child_value.set(map_text);
+                        } else if (map_key == "#cdata") {
+                            child_value.set(map_text);
+                            child_value.set_use_cdata(true);
+                            //container.add_value(it_key, child_value);
+                        } else if (map_key[0] == '-') {
+                            // It's a value attribute
+                            std::string attribute_key = map_key;
+                            std::string attribute_value = map_text;
+                            child_value.add_attribute(attribute_key.erase(0, 1), attribute_value);
+                        } else {
+                            // It's a value
+                            child_value.set(map_text);
+                        }
+                    }
+                }
+                // Add node to container
+                if (is_text) {
+                    // Add text node to container
+                    container.add_value(it_key, std::move(child_value));
+                } else {
+                    // Handle all MapType children recursively
+                    gpds::container child_container;
+                    read_entry(it_node, child_container);
+                    if (!it_key.empty()) {
+                        container.add_value(it_key, std::move(child_container));
+                    }
+                }
+            }
+            break;
+        case Yaml::Node::eType::ScalarType:
+            // Handle ScalarType value
+            std::string it_text = (*it).second.As<std::string>();
+            std::string attribute_key = it_key;
+            std::string attribute_value = it_text;
+            if (it_text == "null") {
+                it_text = "";
+            }
+            if (it_key[0] == '-') {
+                // It's a container attribute
+                container.add_attribute(attribute_key.erase(0, 1), it_text);
+            } else {
+                // It's a text element
+                container.add_value(it_key, it_text);
+            }
+            break;
+        }
+    }
+}

--- a/lib/src/archiver_yaml.cpp
+++ b/lib/src/archiver_yaml.cpp
@@ -146,6 +146,10 @@ archiver_yaml::write_entry(Yaml::Node& root, const container& container) const
 void
 archiver_yaml::read_entry(const Yaml::Node& root, container& container)
 {
+    // Exit if root size is 0
+    if (root.Size() == 0) {
+        return;
+    }
     // Iterate through all children
     for(auto it = root.Begin(); it != root.End(); it++) {
         const std::string& it_key = (*it).first;

--- a/lib/src/archiver_yaml.cpp
+++ b/lib/src/archiver_yaml.cpp
@@ -124,20 +124,10 @@ archiver_yaml::write_entry(Yaml::Node& root, const container& container) const
             }
         }
 
-        // Is key existing?
+        // Is key empty?
         if (!key.empty()) {
-            bool key_exist = false;
-            switch (root[key].Type()) {
-            case Yaml::Node::eType::None:
-                break;
-            case Yaml::Node::eType::SequenceType:
-            case Yaml::Node::eType::MapType:
-            case Yaml::Node::eType::ScalarType:
-                key_exist = true;
-                break;
-            }
-
-            if (key_exist) {
+            // Is key existing?
+            if (key_exist(root, key)) {
                 // If repeated key, add to sequence
                 if (root[key].IsMap() || root[key].IsScalar()) {
                     // Create new sequence and re add first node to sequence
@@ -254,4 +244,30 @@ archiver_yaml::read_entry(const Yaml::Node& root, container& container)
             break;
         }
     }
+}
+
+bool
+archiver_yaml::key_exist(const Yaml::Node& root, const std::string& key) const
+{
+    bool result = false;
+    // Check if the key empty
+    if (key.empty()) {
+        // Key is empty, return false
+        return false;
+    }
+
+    // Copy root node to new node prevent modification
+    Yaml::Node node = root;
+    // If key exist, the node type will not be None
+    switch (node[key].Type()) {
+    case Yaml::Node::eType::None:
+        break;
+    case Yaml::Node::eType::SequenceType:
+    case Yaml::Node::eType::MapType:
+    case Yaml::Node::eType::ScalarType:
+        result = true;
+        break;
+    }
+
+    return result;
 }

--- a/lib/src/serialize.cpp
+++ b/lib/src/serialize.cpp
@@ -1,43 +1,108 @@
 #include "serialize.hpp"
 #include "archiver_xml.hpp"
+#include "archiver_yaml.hpp"
 
 using namespace gpds;
 
 std::pair<bool, std::string>
-serialize::to_string(std::string& str, const std::string_view root_name) const
+serialize::to_string(std::string& str, const std::string_view root_name, enum mode mode) const
 {
-    archiver_xml ar;
-    const bool& ret = ar.save(str, *this, root_name);
-
+    bool ret = false;
+    switch (mode)
+    {
+    case mode::XML:
+        {
+            archiver_xml ar;
+            ret = ar.save(str, *this, root_name);
+        }
+        break;
+    case mode::YAML:
+        {
+            archiver_yaml ar;
+            ret = ar.save(str, *this, root_name);
+        }
+        break;
+    default:
+        return { ret, "Unsupported serialize format." };
+    }
     return { ret, "" };
 }
 
 std::pair<bool, std::string>
-serialize::from_string(std::string_view str, const std::string_view root_name)
+serialize::from_string(std::string_view str, const std::string_view root_name, enum mode mode)
 {
-    archiver_xml ar;
-    const bool& ret = ar.load(std::string{str}, *this, root_name);        // ToDo: Add std::string_view interface to archiver_xml
-
+    bool ret = false;
+    switch (mode)
+    {
+    case mode::XML:
+        {
+            archiver_xml ar;
+            // ToDo: Add std::string_view interface to archiver_xml
+            ret = ar.load(std::string{str}, *this, root_name);
+        }
+        break;
+    case mode::YAML:
+        {
+            archiver_yaml ar;
+            // ToDo: Add std::string_view interface to archiver_yaml
+            ret = ar.load(std::string{str}, *this, root_name);
+        }
+        break;
+    default:
+        return { ret, "Unsupported serialize format." };
+    }
     return { ret, "" };
 }
 
 std::pair<bool, std::string>
-serialize::to_file(const std::filesystem::path& path, const std::string_view root_name) const
+serialize::to_file(const std::filesystem::path& path, const std::string_view root_name, enum mode mode) const
 {
-    archiver_xml ar;
-    const bool& ret = ar.save(path, *this, root_name);
-
+    bool ret = false;
+    switch (mode)
+    {
+    case mode::XML:
+        {
+            archiver_xml ar;
+            ret = ar.save(path, *this, root_name);
+        }
+        break;
+    case mode::YAML:
+        {
+            archiver_yaml ar;
+            ret = ar.save(path, *this, root_name);
+        }
+        break;
+    default:
+        return { ret, "Unsupported serialize format." };
+    }
     return { ret, "" };
 }
 
 std::pair<bool, std::string>
-serialize::from_file(const std::filesystem::path& path, const std::string_view root_name)
+serialize::from_file(const std::filesystem::path& path, const std::string_view root_name, enum mode mode)
 {
     if (!std::filesystem::exists(path))
         return { false, "File does not exist." };
 
-    archiver_xml ar;
-    const bool& ret = ar.load(path, *this, root_name);
+    bool ret = false;
+
+    switch (mode)
+    {
+    case mode::XML:
+        {
+            archiver_xml ar;
+            ret = ar.load(path, *this, root_name);
+        }
+        break;
+    case mode::YAML:
+        {
+            archiver_yaml ar;
+            ret = ar.load(path, *this, root_name);
+        }
+        break;
+    default:
+        return { ret, "Unsupported serialize format." };
+    }
 
     return { ret, "" };
 }

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,9 @@
 [![Packaging status](https://repology.org/badge/vertical-allrepos/gpds.svg)](https://repology.org/project/gpds/versions)
 
 GPDS is a **G**eneral **P**urpose **D**ata **S**erializer implemented as a very small C++ library.
-It allows to serialize C++ classes to and from XML files in a generic format that can be processed
-by other XML processing software (or just for the sake of readability).
+It allows to serialize C++ classes to and from XML/YAML files in a generic format
+that can be processed by other XML/YAML processing software
+(or just for the sake of readability).
 
 Consider the following C++ class:
 ```
@@ -23,14 +24,29 @@ Most serializers would produce the following output when serializing to XML:
     <value type="int">0</value>
 </valuelist>
 ```
-This is not really practical when we want to process the same XML file with other software. GPDS 
-on the other hand produces the following output:
+This is not really practical when we want to process the same XML file with other
+software. GPDS on the other hand produces the following output:
 ```
 <color name="Black" format="rgb">
     <red depth="32">0</red>
     <green depth="32">0</green>
     <blue depth="32">0</blue>
 </color>
+```
+GPDS not only supports XML, but also supports YAML:
+```yaml
+- color:
+    "-format": rgb
+    "-name": Black
+    blue:
+        "#text": 0
+        "-depth": 32
+    green:
+        "#text": 0
+        "-depth": 32
+    red:
+        "#text": 0
+        "-depth": 32
 ```
 
 For more information, see https://gpds.simulton.com

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -2,28 +2,40 @@
 
 #include "gpds/serialize.hpp"
 #include "gpds/archiver_xml.hpp"
+#include "gpds/archiver_yaml.hpp"
 
 #include <sstream>
 
-void gpds_test::test::serialize(std::ostream& stream, gpds::serialize& object, const std::string& rootName)
+void gpds_test::test::serialize(std::ostream& stream, gpds::serialize& object, const std::string& rootName, enum gpds::serialize::mode mode)
 {
-    gpds::archiver_xml ar;
-
     bool ret = false;
-    REQUIRE_NOTHROW(ret = ar.save(stream, object, rootName));
+    REQUIRE((mode == gpds::serialize::mode::XML || mode == gpds::serialize::mode::YAML));
+    if (mode == gpds::serialize::mode::XML) {
+        gpds::archiver_xml ar;
+        REQUIRE_NOTHROW(ret = ar.save(stream, object, rootName));
+    } else if (mode == gpds::serialize::mode::YAML) {
+        gpds::archiver_yaml ar;
+        REQUIRE_NOTHROW(ret = ar.save(stream, object, rootName));
+    }
     REQUIRE(ret);
 }
 
-void gpds_test::test::deserialize(std::istream& stream, gpds::serialize& object, const std::string& root_name)
+void gpds_test::test::deserialize(std::istream& stream, gpds::serialize& object, const std::string& root_name, enum gpds::serialize::mode mode)
 {
-    gpds::archiver_xml ar;
     bool ret = false;
-    REQUIRE_NOTHROW(ret = ar.load(stream, object, root_name));
+    REQUIRE((mode == gpds::serialize::mode::XML || mode == gpds::serialize::mode::YAML));
+    if (mode == gpds::serialize::mode::XML) {
+        gpds::archiver_xml ar;
+        REQUIRE_NOTHROW(ret = ar.load(stream, object, root_name));
+    } else if (mode == gpds::serialize::mode::YAML) {
+        gpds::archiver_yaml ar;
+        REQUIRE_NOTHROW(ret = ar.load(stream, object, root_name));
+    }
     REQUIRE(ret);
 }
 
-void gpds_test::test::deserialize(const std::string& xml_str, gpds::serialize& object, const std::string& root_name)
+void gpds_test::test::deserialize(const std::string& str, gpds::serialize& object, const std::string& root_name, enum gpds::serialize::mode mode)
 {
-    std::stringstream stream(xml_str);
-    return deserialize(stream, object, root_name);
+    std::stringstream stream(str);
+    return deserialize(stream, object, root_name, mode);
 }

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -8,6 +8,7 @@
 
 #include "gpds/serialize.hpp"
 #include "gpds/archiver_xml.hpp"
+#include "gpds/archiver_yaml.hpp"
 
 namespace gpds
 {
@@ -19,8 +20,8 @@ namespace gpds_test
     class test
     {
     public:
-        static void serialize(std::ostream& stream, gpds::serialize& object, const std::string& rootName);
-        static void deserialize(std::istream& stream, gpds::serialize& object, const std::string& rootName);
-        static void deserialize(const std::string& xml_string, gpds::serialize& object, const std::string& rootName);
+        static void serialize(std::ostream& stream, gpds::serialize& object, const std::string& rootName, enum gpds::serialize::mode mode = gpds::serialize::mode::XML);
+        static void deserialize(std::istream& stream, gpds::serialize& object, const std::string& rootName, enum gpds::serialize::mode mode = gpds::serialize::mode::XML);
+        static void deserialize(const std::string& str, gpds::serialize& object, const std::string& rootName, enum gpds::serialize::mode mode = gpds::serialize::mode::XML);
     };
 }

--- a/test/test_suites/25_deserialize_booleans_yaml.cpp
+++ b/test/test_suites/25_deserialize_booleans_yaml.cpp
@@ -1,0 +1,45 @@
+#include "../test.hpp"
+
+#include <vector>
+#include <sstream>
+
+
+static const std::string FILE_CONTENT = R"""(
+---
+data:
+  boolean: 
+    - true
+    - false
+)""";
+
+class test_data_25 : public gpds::serialize
+{
+public:
+    std::vector<bool> data;
+
+    virtual gpds::container to_container() const override
+    {
+        return {};
+    }
+
+    virtual void from_container(const gpds::container& object) override
+    {
+        data = object.get_values<bool>("boolean");
+    }
+};
+
+TEST_CASE("Read Datatype: Boolean")
+{
+    // The "known good" data
+    const std::vector<bool> knownGood = {
+        true,
+        false
+    };
+
+    // Parse test file
+    test_data_25 data;
+    gpds_test::test::deserialize(FILE_CONTENT, data, "data", gpds::serialize::YAML);
+
+    // Ensure that data is the same
+    REQUIRE(data.data == knownGood);
+}

--- a/test/test_suites/26_deserialize_integer_yaml.cpp
+++ b/test/test_suites/26_deserialize_integer_yaml.cpp
@@ -1,0 +1,61 @@
+#include "../test.hpp"
+
+#include <vector>
+
+static const std::string FILE_CONTENT =
+R"""(
+---
+data:
+  int: 
+    - -0
+    - 0
+    - -1
+    - 1
+    - -42
+    - 42
+    - -1024
+    - 1023
+    - -32768
+    - 32767
+)""";
+
+class test_data_26 : public gpds::serialize
+{
+public:
+    std::vector<int> data;
+
+    virtual gpds::container to_container() const override
+    {
+        return {};
+    }
+
+    virtual void from_container(const gpds::container& object) override
+    {
+        data = object.get_values<int>("int");
+    }
+};
+
+TEST_CASE("Read Datatype: Integer")
+{
+    // The "known good" data
+    const std::vector<int> knownGood = {
+        -0,
+        0,
+        -1,
+        1,
+        -42,
+        42,
+        -1024,
+        1023,
+        -32768,
+        32767
+    };
+
+    // Parse test file
+    test_data_26 data;
+    gpds_test::test::deserialize(FILE_CONTENT, data, "data", gpds::serialize::YAML);
+
+    // Ensure that data is the same
+    REQUIRE(data.data == knownGood);
+}
+

--- a/test/test_suites/27_deserialize_floats_yaml.cpp
+++ b/test/test_suites/27_deserialize_floats_yaml.cpp
@@ -1,0 +1,48 @@
+#include "../test.hpp"
+
+#include <vector>
+
+static const std::string FILE_CONTENT =
+R"""(
+---
+data: 
+  real: 
+    - "-0."
+    - 0.
+    - "-1."
+    - 1.
+)""";
+
+class test_data_27 : public gpds::serialize
+{
+public:
+    std::vector<double> data;
+
+    virtual gpds::container to_container() const override
+    {
+        return {};
+    }
+
+    virtual void from_container(const gpds::container& object) override
+    {
+        data = object.get_values<double>("real");
+    }
+};
+
+TEST_CASE("Read Datatype: Real")
+{
+    // The "known good" data
+    const std::vector<double> knownGood = {
+        0,
+        0,
+        -1,
+        1
+    };
+
+    // Parse test file
+    test_data_27 data;
+    gpds_test::test::deserialize(FILE_CONTENT, data, "data", gpds::serialize::YAML);
+
+    // Ensure that data is the same
+    REQUIRE(data.data == knownGood);
+}

--- a/test/test_suites/28_deserialize_strings_yaml.cpp
+++ b/test/test_suites/28_deserialize_strings_yaml.cpp
@@ -1,0 +1,71 @@
+#include <vector>
+#include <sstream>
+#include "../test.hpp"
+
+static const std::string FILE_CONTENT =
+R"""(
+---
+data: 
+  string: 
+    - "Hello World!"
+    - "2019-08-09"
+    - 1234test
+    - 1.2test
+    - test1234
+    - test1.2
+    - "1 + x = 5"
+    - "1970-01-01"
+    - 04.02.2001
+    - 12/5/18
+    - "2018-1-13"
+    - a
+    - _under_score_
+    - "+-={}[]/\!@#$%^&*()_"
+    - \n\r\b
+)""";
+
+class test_data_28 : public gpds::serialize
+{
+public:
+    std::vector<std::string> data;
+
+    virtual gpds::container to_container() const override
+    {
+        return {};
+    }
+
+    virtual void from_container(const gpds::container& object) override
+    {
+        data = object.get_values<std::string>("string");
+    }
+};
+
+TEST_CASE("Read Datatype: String")
+{
+    // The "known good" data
+    const std::vector<std::string> knownGood = {
+        "Hello World!",
+        "2019-08-09",
+        "1234test",
+        "1.2test",
+        "test1234",
+        "test1.2",
+        "1 + x = 5",
+        "1970-01-01",
+        "04.02.2001",
+        "12/5/18",
+        "2018-1-13",
+        "a",
+        "_under_score_",
+        "+-={}[]/\\!@#$%^&*()_",
+        "\\n\\r\\b"
+    };
+
+    // Parse test file
+    test_data_28 data;
+    gpds_test::test::deserialize(FILE_CONTENT, data, "data", gpds::serialize::mode::YAML);
+
+    // Ensure that data is the same
+    REQUIRE(data.data == knownGood);
+}
+

--- a/test/test_suites/29_deserialize_attributes_yaml.cpp
+++ b/test/test_suites/29_deserialize_attributes_yaml.cpp
@@ -1,0 +1,117 @@
+#include "../test.hpp"
+
+#include <vector>
+#include <sstream>
+
+static const std::string FILE_CONTENT =
+R"""(
+---
+data: 
+  value: 
+    - "#text": 5
+      "-attribute": true
+    - "#text": 0
+      "-attribute": false
+    - "#text": null
+      "-attribute": 0
+    - "#text": lorem
+      "-attribute": 1
+    - "#text": null
+      "-attribute": 42
+    - "#text": 1234
+      "-attribute": "-17"
+    - "#text": null
+      "-attribute": "-0"
+    - "#text": -1234
+      "-attribute": 0
+    - "#text": null
+      "-attribute": "-1"
+    - "#text": 2.3
+      "-attribute": 1
+    - "#text": null
+      "-attribute": "Hello GPDS!"
+    - "#text": null
+      "-attribute": "Hello GPDS!"
+)""";
+
+using data = std::vector<std::variant<
+    bool,
+    int,
+    double,
+    std::string
+>>;
+
+// The "known good" data
+static const data knownGood = {
+    true,
+    false,
+    0,
+    1,
+    42,
+    -17,
+    -0.0,
+    0.0,
+    -1.0,
+    1.0,
+    std::string("Hello GPDS!"),
+    std::string("Hello GPDS!"),
+};
+
+class test_data_29 : public gpds::serialize
+{
+public:
+    data d;
+
+    virtual gpds::container to_container() const override
+    {
+        return {};
+    }
+
+    virtual void from_container(const gpds::container& object) override
+    {
+        // Get all values
+        for (auto it = object.values.cbegin(); it != object.values.cend(); it++) {
+            if (it->first.compare("value") == 0) {
+                // Figure out which type we need
+                std::size_t index = std::distance(object.values.cbegin(), it);
+                switch (index) {
+                    case 0:
+                    case 1:
+                        d.emplace_back(it->second.get_attribute<bool>("attribute").value());
+                        break;
+
+                    case 2:
+                    case 3:
+                    case 4:
+                    case 5:
+                        d.emplace_back(it->second.get_attribute<int>("attribute").value());
+                        break;
+
+                    case 6:
+                    case 7:
+                    case 8:
+                    case 9:
+                        d.emplace_back(it->second.get_attribute<double>("attribute").value());
+                        break;
+
+                    case 10:
+                    case 11:
+                        d.emplace_back(it->second.get_attribute<std::string>("attribute").value());
+                        break;
+                }
+            }
+        }
+    }
+};
+
+TEST_CASE("Read Attributes: Value Attributes")
+{
+    // Parse test file
+    test_data_29 testData;
+    gpds_test::test::deserialize(FILE_CONTENT, testData, "data", gpds::serialize::YAML);
+
+    // Ensure that data is the same
+    REQUIRE(testData.d.size() == knownGood.size());
+    REQUIRE(testData.d == knownGood);
+}
+

--- a/test/test_suites/30_deserialize_container_attributes_yaml.cpp
+++ b/test/test_suites/30_deserialize_container_attributes_yaml.cpp
@@ -1,0 +1,109 @@
+#include <vector>
+#include <sstream>
+#include "../test.hpp"
+#include "gpds/serialize.hpp"
+
+static const std::string FILE_CONTENT =
+R"""(
+---
+data: 
+  value: 
+    - "-attribute": true
+    - "-attribute": false
+    - "-attribute": 0
+    - "-attribute": 1
+    - "-attribute": 42
+    - "-attribute": "-17"
+    - "-attribute": "-0"
+    - "-attribute": 0
+    - "-attribute": "-1"
+    - "-attribute": 1
+    - "-attribute": "Hello GPDS!"
+)""";
+
+using data = std::vector<std::variant<
+    bool,
+    int,
+    double,
+    std::string
+>>;
+
+// The "known good" data
+static const data knownGood = {
+    true,
+    false,
+    0,
+    1,
+    42,
+    -17,
+    -0.0,
+    0.0,
+    -1.0,
+    1.0,
+    std::string("Hello GPDS!")
+};
+
+class test_data_20 : public gpds::serialize
+{
+public:
+    data d;
+
+    virtual gpds::container to_container() const override
+    {
+        return {};
+    }
+
+    virtual void from_container(const gpds::container& object) override
+    {
+        const auto& valueContainers = object.get_values<gpds::container*>("value");
+        for (std::size_t i = 0; i < valueContainers.size(); i++) {
+            const gpds::container* c = valueContainers.at(i);
+            REQUIRE(c);
+
+            // Figure out which type we need
+            switch (i) {
+                case 0:
+                case 1:
+                    d.emplace_back(c->get_attribute<bool>("attribute").value());
+                    break;
+
+                case 2:
+                case 3:
+                case 4:
+                case 5:
+                    d.emplace_back(c->get_attribute<int>("attribute").value());
+                    break;
+
+                case 6:
+                case 7:
+                case 8:
+                case 9:
+                    d.emplace_back(c->get_attribute<double>("attribute").value());
+                    break;
+
+                case 10:
+                    d.emplace_back(c->get_attribute<std::string>("attribute").value());
+                    break;
+            }
+        }
+
+
+        for (const gpds::container* valueContainer : object.get_values<gpds::container*>("value")) {
+            REQUIRE(valueContainer);
+
+
+        }
+    }
+};
+
+TEST_CASE("Read Attributes: Container Attributes")
+{
+    // Parse test file
+    test_data_20 testData;
+    gpds_test::test::deserialize(FILE_CONTENT, testData, "data", gpds::serialize::mode::YAML);
+
+    // Ensure that data is the same
+    CHECK_EQ(testData.d.size(), knownGood.size());
+    CHECK_EQ(testData.d, knownGood);
+}
+

--- a/test/test_suites/37_deserializing_empty_container_yaml.cpp
+++ b/test/test_suites/37_deserializing_empty_container_yaml.cpp
@@ -1,0 +1,65 @@
+#include <sstream>
+
+#include "gpds/archiver_yaml.hpp"
+#include "../test.hpp"
+
+static const std::string FILE_CONTENT_1 =
+R"""(
+---
+data
+)""";
+
+static const std::string FILE_CONTENT_2 =
+R"""(
+---
+data: 
+  test
+)""";
+
+static const std::string FILE_CONTENT_3 =
+R"""(
+---
+data: 
+  test:
+    value: 42
+)""";
+
+TEST_CASE("Empty elements are deserialized correctly (1)")
+{
+    std::stringstream ss(FILE_CONTENT_1);
+    gpds::container container;
+
+    gpds::archiver_yaml ar;
+    ar.load(ss, container, "data");
+
+    std::vector<std::string> vector;
+    vector = container.get_values<std::string>("test");
+    REQUIRE(vector.size() == 0);
+}
+
+TEST_CASE("Empty elements are deserialized correctly (2)")
+{
+    std::stringstream ss(FILE_CONTENT_2);
+    gpds::container container;
+
+    gpds::archiver_yaml ar;
+    ar.load(ss, container, "data");
+
+    for (const gpds::container* cc : container.get_values<gpds::container*>("test")) {
+        REQUIRE(cc);
+    }
+}
+
+TEST_CASE("Empty elements are deserialized correctly (3)")
+{
+    std::stringstream ss(FILE_CONTENT_3);
+    gpds::container container;
+
+    gpds::archiver_yaml ar;
+    ar.load(ss, container, "data");
+
+    for (const gpds::container* cc : container.get_values<gpds::container*>("test")) {
+        REQUIRE(cc);
+        CHECK_EQ(cc->get_value<int>("value").value_or(-1), 42);
+    }
+}

--- a/test/test_suites/38_load_and_save_file_yaml.cpp
+++ b/test/test_suites/38_load_and_save_file_yaml.cpp
@@ -1,0 +1,61 @@
+#include "../test.hpp"
+
+#include "gpds/archiver_yaml.hpp"
+
+static constexpr const char* brand = "Ferrari";
+
+TEST_CASE("Serialize and deserialize a container to and from a file")
+{
+    // Create a container
+    gpds::container container;
+    container.add_value("brand", brand);
+
+    // Setup
+    gpds::archiver_yaml ar;
+    std::filesystem::path path("test_38.yaml");
+
+    // Make sure the file doesn't exist
+    if (std::filesystem::exists(path)) {
+        REQUIRE_MESSAGE(std::filesystem::remove(path), "could not remove file");
+    }
+
+    // Save
+    REQUIRE(ar.save(path, container, "data"));
+
+    // Load
+    gpds::container newContainer;
+    REQUIRE(ar.load(path, newContainer, "data"));
+
+    // Check that the value is correct
+    auto brandOpt = newContainer.get_value<std::string>("brand");
+    CHECK(brandOpt.has_value());
+    CHECK(brandOpt.value() == brand);
+
+    // Clean up
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("Deserializing from an inexistent file returns false") {
+    // Setup
+    gpds::archiver_yaml ar;
+    std::filesystem::path path("test_38_inexistent.yaml");
+
+    // Make sure the file doesn't exist
+    if (std::filesystem::exists(path))
+        REQUIRE_MESSAGE(std::filesystem::remove(path), "could not remove file");
+
+    // Load and check that it returns false
+    gpds::container container;
+    REQUIRE_FALSE(ar.load(path, container, "data"));
+}
+
+TEST_CASE("Serializing to an invalid file path") {
+    // Setup
+    gpds::archiver_yaml ar;
+    std::filesystem::path path("/");
+
+    // Load and make sure it returns false
+    gpds::container container;
+    container.add_attribute("height", "123px");
+    REQUIRE_FALSE(ar.save(path, container, "div"));
+}

--- a/test/test_suites/CMakeLists.txt
+++ b/test/test_suites/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(
         26_deserialize_integer_yaml.cpp
         27_deserialize_floats_yaml.cpp
         28_deserialize_strings_yaml.cpp
+        29_deserialize_attributes_yaml.cpp
 
         attributes.cpp
         cdata.cpp

--- a/test/test_suites/CMakeLists.txt
+++ b/test/test_suites/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
         25_deserialize_booleans_yaml.cpp
         26_deserialize_integer_yaml.cpp
         27_deserialize_floats_yaml.cpp
+        28_deserialize_strings_yaml.cpp
 
         attributes.cpp
         cdata.cpp

--- a/test/test_suites/CMakeLists.txt
+++ b/test/test_suites/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(
         28_deserialize_strings_yaml.cpp
         29_deserialize_attributes_yaml.cpp
         30_deserialize_container_attributes_yaml.cpp
+        37_deserializing_empty_container_yaml.cpp
 
         attributes.cpp
         cdata.cpp

--- a/test/test_suites/CMakeLists.txt
+++ b/test/test_suites/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(
         16_addition_assignment.cpp
         17_deserializing_empty_container.cpp
         18_load_and_save_file.cpp
+        25_deserialize_booleans_yaml.cpp
 
         attributes.cpp
         cdata.cpp

--- a/test/test_suites/CMakeLists.txt
+++ b/test/test_suites/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(
         29_deserialize_attributes_yaml.cpp
         30_deserialize_container_attributes_yaml.cpp
         37_deserializing_empty_container_yaml.cpp
+        38_load_and_save_file_yaml.cpp
 
         attributes.cpp
         cdata.cpp

--- a/test/test_suites/CMakeLists.txt
+++ b/test/test_suites/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(
         18_load_and_save_file.cpp
         25_deserialize_booleans_yaml.cpp
         26_deserialize_integer_yaml.cpp
+        27_deserialize_floats_yaml.cpp
 
         attributes.cpp
         cdata.cpp

--- a/test/test_suites/CMakeLists.txt
+++ b/test/test_suites/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(
         27_deserialize_floats_yaml.cpp
         28_deserialize_strings_yaml.cpp
         29_deserialize_attributes_yaml.cpp
+        30_deserialize_container_attributes_yaml.cpp
 
         attributes.cpp
         cdata.cpp

--- a/test/test_suites/CMakeLists.txt
+++ b/test/test_suites/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(
         17_deserializing_empty_container.cpp
         18_load_and_save_file.cpp
         25_deserialize_booleans_yaml.cpp
+        26_deserialize_integer_yaml.cpp
 
         attributes.cpp
         cdata.cpp


### PR DESCRIPTION
### Changelog summary

- Add a lightweight miniyaml library whose license is MIT and compatible with GPDS
- Added the implementation of archiver_yaml without breaking the API of GPDS
- Achieve code compatibility with old projects
- Added YAML-related test code and passed the test
- Modify readme to reflect support for YAML

### List of new testsuits and pass status

- [x] 25_deserialize_booleans_yaml.cpp
- [x] 26_deserialize_integer_yaml.cpp
- [x] 27_deserialize_floats_yaml.cpp
- [x] 28_deserialize_strings_yaml.cpp
- [x] 29_deserialize_attributes_yaml.cpp
- [x] 30_deserialize_container_attributes_yaml.cpp
- [x] 37_deserializing_empty_container_yaml.cpp
- [x] 38_load_and_save_file_yaml.cpp

```bash
"doctest" start time: Jul 08 20:28 CST
Output:
----------------------------------------------------------
[doctest] doctest version is "2.4.10"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:  46 |  46 passed | 0 failed | 0 skipped
[doctest] assertions: 290 | 290 passed | 0 failed |
[doctest] Status: SUCCESS!
<end of output>
Test time =   0.00 sec
----------------------------------------------------------
Test Passed.
"doctest" end time: Jul 08 20:28 CST
"doctest" time elapsed: 00:00:00
----------------------------------------------------------

End testing: Jul 08 20:28 CST
```
